### PR TITLE
Fix workflow issue title injection and remove scheduled auto-approve

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,9 +1,6 @@
 name: Auto-Approve Proposals
 
 on:
-  schedule:
-    - cron: "0 9,21 * * *"  # 1 hour after propose (09:00, 21:00 UTC)
-
   workflow_dispatch:
     inputs:
       delay:

--- a/.github/workflows/minion.yml
+++ b/.github/workflows/minion.yml
@@ -175,7 +175,7 @@ jobs:
           else
             # Issue label trigger (minion-ready or minion-approved)
             ISSUE_NUM="${{ github.event.issue.number }}"
-            ISSUE_TITLE="${{ github.event.issue.title }}"
+            ISSUE_TITLE="$ISSUE_TITLE_ENV"
             ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json body -q '.body')
 
             # Check for embedded task YAML (from minion-proposal issues)
@@ -213,6 +213,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.PARTIO_PAT }}
+          ISSUE_TITLE_ENV: ${{ github.event.issue.title }}
 
       # Run the minion
       - name: Execute minion

--- a/cmd/minions/doc.go
+++ b/cmd/minions/doc.go
@@ -2,19 +2,14 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/partio-io/minions/internal/checks"
-	"github.com/partio-io/minions/internal/claude"
-	"github.com/partio-io/minions/internal/git"
-	"github.com/partio-io/minions/internal/pr"
+	"github.com/partio-io/minions/internal/pipeline"
 	"github.com/partio-io/minions/internal/prompt"
-	"github.com/partio-io/minions/internal/worktree"
 )
 
 func newDocCmd() *cobra.Command {
@@ -62,116 +57,51 @@ func newDocCmd() *cobra.Command {
 				return fmt.Errorf("building doc prompt: %w", err)
 			}
 
-			if dryRun {
-				fmt.Println()
-				fmt.Println("=== DRY RUN: Generated Prompt ===")
-				fmt.Println(docPrompt)
-				fmt.Println("=== END PROMPT ===")
-				return nil
-			}
-
-			// Create worktree in docs repo
-			docsRepo := filepath.Join(workspaceRoot, "docs")
 			taskID := fmt.Sprintf("doc-update-%s-%s", strings.ReplaceAll(prRepo, "/", "-"), prNumber)
 
-			if _, err := os.Stat(docsRepo); os.IsNotExist(err) {
-				return fmt.Errorf("docs repo not found at %s", docsRepo)
-			}
-
-			fmt.Println("--- Creating worktree ---")
-			wtPath, err := worktree.Create(docsRepo, taskID)
-			if err != nil {
-				return fmt.Errorf("creating worktree: %w", err)
-			}
-			fmt.Printf("Worktree: %s\n", wtPath)
-
-			// Run Claude Code
-			fmt.Println("--- Running Claude Code ---")
 			maxTurns := cfg.MaxTurns
 			if maxTurns > 20 {
 				maxTurns = 20
 			}
-			err = claude.Run(claude.Opts{
-				Prompt:   docPrompt,
-				CWD:      wtPath,
-				MaxTurns: maxTurns,
-			})
-			if err != nil {
-				slog.Warn("claude exited with error", "error", err)
-			}
 
-			// Check for .no-update-needed
-			noUpdatePath := filepath.Join(wtPath, ".no-update-needed")
-			if data, err := os.ReadFile(noUpdatePath); err == nil {
-				fmt.Printf("Claude determined no docs update is needed:\n%s\n", string(data))
-				worktree.Cleanup(docsRepo, taskID)
-				return nil
-			}
-
-			// Run docs checks
-			fmt.Println("--- Running docs checks ---")
-			output, err := checks.Run(wtPath)
-			if err != nil {
-				fmt.Println("--- Checks failed, retrying ---")
-				retryPrompt := fmt.Sprintf("The following docs checks failed. Please fix:\n\n%s\n\nFix the errors. Do not change anything beyond what's needed to fix the failures.", output)
-
-				_ = claude.Run(claude.Opts{
-					Prompt:   retryPrompt,
-					CWD:      wtPath,
-					MaxTurns: 10,
-				})
-
-				if _, err := checks.Run(wtPath); err != nil {
-					worktree.Cleanup(docsRepo, taskID)
-					return fmt.Errorf("docs checks still failing after retry")
-				}
-			}
-
-			// Check for actual changes
-			status, _ := git.ExecGitDir(wtPath, "status", "--porcelain")
-			if strings.TrimSpace(status) == "" {
-				fmt.Println("No changes made to docs.")
-				worktree.Cleanup(docsRepo, taskID)
-				return nil
-			}
-
-			// Create docs PR
-			fmt.Println("--- Creating docs PR ---")
-			branchName := "minion/" + taskID
-
-			if _, err := git.ExecGitDir(wtPath, "add", "-A"); err != nil {
-				return fmt.Errorf("staging changes: %w", err)
-			}
-
-			commitMsg := fmt.Sprintf("docs: update for %s#%s\n\nAutomated documentation update by partio-io/minions doc-minion.\nSource PR: %s#%s\n\nCo-Authored-By: Claude <noreply@anthropic.com>", prRepo, prNumber, prRepo, prNumber)
-			if _, err := git.ExecGitDir(wtPath, "commit", "-m", commitMsg); err != nil {
-				return fmt.Errorf("committing: %w", err)
-			}
-
-			if _, err := git.ExecGitDir(wtPath, "push", "-u", "origin", branchName); err != nil {
-				return fmt.Errorf("pushing: %w", err)
-			}
-
-			// Fetch source PR title
 			sourcePRTitle := prompt.GHPRField(prRepo, prNumber, "title")
 
-			docsPRURL, err := pr.CreateDocsPR(prRepo, prNumber, branchName, sourcePRTitle)
-			if err != nil {
-				return fmt.Errorf("creating docs PR: %w", err)
+			def := pipeline.Def{
+				Name:           "doc-updater",
+				TaskID:         taskID,
+				WorkspaceRoot:  workspaceRoot,
+				TargetRepos:    []string{"docs"},
+				PromptText:     docPrompt,
+				MaxTurns:       maxTurns,
+				AllowedTools:   "Edit,Write,Read,Glob,Grep,Bash",
+				SkipMarker:     ".no-update-needed",
+				RunChecks:      true,
+				RetryOnFail:    true,
+				RetryMaxTurns:  10,
+				CreatePR:       true,
+				PRLabels:       []string{"minion", "documentation"},
+				PRRepo:         "partio-io/docs",
+				CommitMsg:      fmt.Sprintf("docs: update for %s#%s\n\nAutomated documentation update by partio-io/minions doc-minion.\nSource PR: %s#%s\n\nCo-Authored-By: Claude <noreply@anthropic.com>", prRepo, prNumber, prRepo, prNumber),
+				PRTitle:        fmt.Sprintf("[docs] Update for %s#%s: %s", prRepo, prNumber, sourcePRTitle),
+				PRBody:         fmt.Sprintf("## Summary\n\nAutomated documentation update for %s#%s.\n\n**Source PR:** https://github.com/%s/pull/%s\n\n---\n\n*This PR was created by the doc-minion. Please review carefully.*", prRepo, prNumber, prRepo, prNumber),
+				SourcePRRepo:   prRepo,
+				SourcePRNumber: prNumber,
+				DryRun:         dryRun,
 			}
 
-			fmt.Printf("Docs PR created: %s\n", docsPRURL)
+			result, err := pipeline.Execute(def)
+			if err != nil {
+				return err
+			}
 
-			// Cross-link
-			fmt.Println("--- Cross-linking PRs ---")
-			pr.CommentOnPR(prRepo, prNumber, fmt.Sprintf("Documentation update PR: %s", docsPRURL))
+			if result.Skipped {
+				return nil
+			}
 
-			// Cleanup
-			fmt.Println("--- Cleaning up ---")
-			worktree.Cleanup(docsRepo, taskID)
-
+			for _, url := range result.PRURLs {
+				fmt.Printf("Docs PR: %s\n", url)
+			}
 			fmt.Printf("\nDONE: Documentation updated for %s\n", prRef)
-			fmt.Printf("Docs PR: %s\n", docsPRURL)
 			return nil
 		},
 	}

--- a/cmd/minions/readme.go
+++ b/cmd/minions/readme.go
@@ -2,19 +2,14 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/partio-io/minions/internal/claude"
-	"github.com/partio-io/minions/internal/git"
-	"github.com/partio-io/minions/internal/pr"
+	"github.com/partio-io/minions/internal/pipeline"
 	"github.com/partio-io/minions/internal/prompt"
-	"github.com/partio-io/minions/internal/worktree"
 )
 
 func newReadmeCmd() *cobra.Command {
@@ -42,7 +37,6 @@ func newReadmeCmd() *cobra.Command {
 			prRepo := parts[0]
 			prNumber := parts[1]
 
-			// Extract short repo name (e.g., "app" from "partio-io/app")
 			repoShort := prRepo
 			if idx := strings.LastIndex(prRepo, "/"); idx >= 0 {
 				repoShort = prRepo[idx+1:]
@@ -57,7 +51,7 @@ func newReadmeCmd() *cobra.Command {
 				workspaceRoot = filepath.Dir(wd)
 			}
 
-			// Resolve prompts directory (relative to minions repo)
+			// Resolve prompts directory
 			if !filepath.IsAbs(promptsDir) {
 				minionsDir := filepath.Join(workspaceRoot, "minions")
 				promptsDir = filepath.Join(minionsDir, promptsDir)
@@ -75,115 +69,45 @@ func newReadmeCmd() *cobra.Command {
 				return fmt.Errorf("building readme prompt: %w", err)
 			}
 
-			if dryRun {
-				fmt.Println()
-				fmt.Println("=== DRY RUN: Generated Prompt ===")
-				fmt.Println(readmePrompt)
-				fmt.Println("=== END PROMPT ===")
-				return nil
-			}
-
-			// Create worktree in the same repo the PR was merged to
-			targetRepo := filepath.Join(workspaceRoot, repoShort)
 			taskID := fmt.Sprintf("readme-update-%s-%s", strings.ReplaceAll(prRepo, "/", "-"), prNumber)
 
-			if _, err := os.Stat(targetRepo); os.IsNotExist(err) {
-				return fmt.Errorf("target repo not found at %s", targetRepo)
-			}
-
-			fmt.Println("--- Creating worktree ---")
-			wtPath, err := worktree.Create(targetRepo, taskID)
-			if err != nil {
-				return fmt.Errorf("creating worktree: %w", err)
-			}
-			fmt.Printf("Worktree: %s\n", wtPath)
-
-			// Run Claude Code with max 10 turns (README is a small task)
-			fmt.Println("--- Running Claude Code ---")
-			maxTurns := 10
-			err = claude.Run(claude.Opts{
-				Prompt:   readmePrompt,
-				CWD:      wtPath,
-				MaxTurns: maxTurns,
-			})
-			if err != nil {
-				slog.Warn("claude exited with error", "error", err)
-			}
-
-			// Check for .no-update-needed
-			noUpdatePath := filepath.Join(wtPath, ".no-update-needed")
-			if data, err := os.ReadFile(noUpdatePath); err == nil {
-				fmt.Printf("Claude determined no README update is needed:\n%s\n", string(data))
-				worktree.Cleanup(targetRepo, taskID)
-				return nil
-			}
-
-			// Check for actual changes
-			status, _ := git.ExecGitDir(wtPath, "status", "--porcelain")
-			if strings.TrimSpace(status) == "" {
-				fmt.Println("No changes made to README.")
-				worktree.Cleanup(targetRepo, taskID)
-				return nil
-			}
-
-			// Create README PR
-			fmt.Println("--- Creating README PR ---")
-			branchName := "minion/" + taskID
-
-			if _, err := git.ExecGitDir(wtPath, "add", "README.md"); err != nil {
-				return fmt.Errorf("staging changes: %w", err)
-			}
-
 			sourcePRTitle := prompt.GHPRField(prRepo, prNumber, "title")
-			commitMsg := fmt.Sprintf("docs: update README for %s#%s\n\nAutomated README update by partio-io/minions readme-minion.\nSource PR: %s#%s — %s\n\nCo-Authored-By: Claude <noreply@anthropic.com>", prRepo, prNumber, prRepo, prNumber, sourcePRTitle)
-			if _, err := git.ExecGitDir(wtPath, "commit", "-m", commitMsg); err != nil {
-				return fmt.Errorf("committing: %w", err)
+
+			def := pipeline.Def{
+				Name:           "readme-updater",
+				TaskID:         taskID,
+				WorkspaceRoot:  workspaceRoot,
+				TargetRepos:    []string{repoShort},
+				PromptText:     readmePrompt,
+				MaxTurns:       10,
+				AllowedTools:   "Edit,Write,Read,Glob,Grep,Bash",
+				SkipMarker:     ".no-update-needed",
+				RunChecks:      false,
+				CreatePR:       true,
+				PRLabels:       []string{"minion"},
+				PRRepo:         prRepo,
+				StageFiles:     []string{"README.md"},
+				CommitMsg:      fmt.Sprintf("docs: update README for %s#%s\n\nAutomated README update by partio-io/minions readme-minion.\nSource PR: %s#%s — %s\n\nCo-Authored-By: Claude <noreply@anthropic.com>", prRepo, prNumber, prRepo, prNumber, sourcePRTitle),
+				PRTitle:        fmt.Sprintf("[readme] Update for %s#%s: %s", prRepo, prNumber, sourcePRTitle),
+				PRBody:         fmt.Sprintf("## Summary\n\nAutomated README update for %s#%s.\n\n**Source PR:** https://github.com/%s/pull/%s\n\n---\n\n*This PR was created by the readme-minion. Please review carefully.*", prRepo, prNumber, prRepo, prNumber),
+				SourcePRRepo:   prRepo,
+				SourcePRNumber: prNumber,
+				DryRun:         dryRun,
 			}
 
-			if _, err := git.ExecGitDir(wtPath, "push", "-u", "origin", branchName); err != nil {
-				return fmt.Errorf("pushing: %w", err)
-			}
-
-			// Create PR with minion label (critical for infinite loop prevention)
-			prTitle := fmt.Sprintf("[readme] Update for %s#%s: %s", prRepo, prNumber, sourcePRTitle)
-			prBody := fmt.Sprintf(`## Summary
-
-Automated README update for %s#%s.
-
-**Source PR:** https://github.com/%s/pull/%s
-
----
-
-*This PR was created by the readme-minion. Please review carefully.*`, prRepo, prNumber, prRepo, prNumber)
-
-			ghArgs := []string{
-				"pr", "create",
-				"--repo", prRepo,
-				"--head", branchName,
-				"--title", prTitle,
-				"--body", prBody,
-				"--label", "minion",
-			}
-
-			cmd2 := exec.Command("gh", ghArgs...)
-			out, err := cmd2.CombinedOutput()
+			result, err := pipeline.Execute(def)
 			if err != nil {
-				return fmt.Errorf("creating PR: %s: %w", strings.TrimSpace(string(out)), err)
+				return err
 			}
-			readmePRURL := strings.TrimSpace(string(out))
 
-			fmt.Printf("README PR created: %s\n", readmePRURL)
+			if result.Skipped {
+				return nil
+			}
 
-			// Cross-link back to the source PR
-			fmt.Println("--- Cross-linking PRs ---")
-			pr.CommentOnPR(prRepo, prNumber, fmt.Sprintf("README update PR: %s", readmePRURL))
-
-			// Cleanup
-			fmt.Println("--- Cleaning up ---")
-			worktree.Cleanup(targetRepo, taskID)
-
+			for _, url := range result.PRURLs {
+				fmt.Printf("README PR: %s\n", url)
+			}
 			fmt.Printf("\nDONE: README updated for %s\n", prRef)
-			fmt.Printf("README PR: %s\n", readmePRURL)
 			return nil
 		},
 	}

--- a/cmd/minions/run.go
+++ b/cmd/minions/run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,34 +11,38 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/partio-io/minions/internal/checks"
-	"github.com/partio-io/minions/internal/claude"
-	"github.com/partio-io/minions/internal/git"
-	"github.com/partio-io/minions/internal/pr"
+	"github.com/partio-io/minions/internal/agent"
+	appcontext "github.com/partio-io/minions/internal/context"
+	"github.com/partio-io/minions/internal/pipeline"
 	"github.com/partio-io/minions/internal/prompt"
 	"github.com/partio-io/minions/internal/task"
-	"github.com/partio-io/minions/internal/worktree"
 )
 
 func newRunCmd() *cobra.Command {
 	var dryRun bool
 	var parallel int
+	var agentName string
+	var prRef string
+	var contextJSON string
 
 	cmd := &cobra.Command{
-		Use:   "run <path>",
-		Short: "Execute task specs end-to-end",
-		Long:  `Execute one or more task YAML files. Creates worktrees, runs Claude Code, validates checks, and creates PRs.`,
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			target := args[0]
+		Use:   "run [path]",
+		Short: "Execute task specs or agent types end-to-end",
+		Long: `Execute one or more task YAML files, or run a named agent type.
 
+Examples:
+  minions run tasks/my-task.yaml
+  minions run tasks/ --parallel 3
+  minions run --agent doc-updater --pr partio-io/cli#42
+  minions run --agent readme-updater --pr partio-io/app#42`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if cfg.DryRun {
 				dryRun = true
 			}
 
 			workspaceRoot := cfg.WorkspaceRoot
 			if workspaceRoot == "" {
-				// Default: parent of the directory containing the binary or cwd
 				wd, err := os.Getwd()
 				if err != nil {
 					return fmt.Errorf("getting working directory: %w", err)
@@ -45,63 +50,80 @@ func newRunCmd() *cobra.Command {
 				workspaceRoot = filepath.Dir(wd)
 			}
 
-			// Load tasks
-			var tasks []*task.Task
-			info, err := os.Stat(target)
-			if err != nil {
-				return fmt.Errorf("cannot access %s: %w", target, err)
+			// Agent mode: --agent flag specified
+			if agentName != "" {
+				return runAgent(agentName, prRef, contextJSON, workspaceRoot, dryRun)
 			}
 
-			if info.IsDir() {
-				tasks, err = task.LoadDir(target)
-				if err != nil {
-					return err
-				}
-			} else {
-				t, err := task.LoadFile(target)
-				if err != nil {
-					return err
-				}
-				tasks = []*task.Task{t}
+			// Task mode: path argument required
+			if len(args) == 0 {
+				return fmt.Errorf("either a task path or --agent is required")
 			}
 
-			if len(tasks) == 0 {
-				fmt.Println("No task files found in", target)
-				return nil
-			}
-
-			fmt.Printf("Found %d task(s) to process\n", len(tasks))
-			fmt.Printf("Workspace root: %s\n", workspaceRoot)
-			fmt.Printf("Parallel: %d\n", parallel)
-			fmt.Printf("Dry run: %v\n\n", dryRun)
-
-			var failed bool
-			if parallel <= 1 {
-				for _, t := range tasks {
-					if err := executeTask(t, workspaceRoot, dryRun); err != nil {
-						slog.Error("task failed", "task", t.ID, "error", err)
-						failed = true
-					}
-				}
-			} else {
-				failed = runParallel(tasks, workspaceRoot, dryRun, parallel)
-			}
-
-			fmt.Println("==========================================")
-			fmt.Println("All tasks complete.")
-			fmt.Println("==========================================")
-
-			if failed {
-				return fmt.Errorf("one or more tasks failed")
-			}
-			return nil
+			return runTasks(args[0], workspaceRoot, dryRun, parallel)
 		},
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview generated prompt without executing")
 	cmd.Flags().IntVar(&parallel, "parallel", 1, "max parallel task executions")
+	cmd.Flags().StringVar(&agentName, "agent", "", "agent type to run (e.g., doc-updater, readme-updater)")
+	cmd.Flags().StringVar(&prRef, "pr", "", "PR reference for PR-triggered agents (e.g., partio-io/cli#42)")
+	cmd.Flags().StringVar(&contextJSON, "context", "", "JSON context for the agent")
 
 	return cmd
+}
+
+// runTasks executes task YAML files using the task-runner pipeline.
+func runTasks(target, workspaceRoot string, dryRun bool, parallel int) error {
+	var tasks []*task.Task
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("cannot access %s: %w", target, err)
+	}
+
+	if info.IsDir() {
+		tasks, err = task.LoadDir(target)
+		if err != nil {
+			return err
+		}
+	} else {
+		t, err := task.LoadFile(target)
+		if err != nil {
+			return err
+		}
+		tasks = []*task.Task{t}
+	}
+
+	if len(tasks) == 0 {
+		fmt.Println("No task files found in", target)
+		return nil
+	}
+
+	fmt.Printf("Found %d task(s) to process\n", len(tasks))
+	fmt.Printf("Workspace root: %s\n", workspaceRoot)
+	fmt.Printf("Parallel: %d\n", parallel)
+	fmt.Printf("Dry run: %v\n\n", dryRun)
+
+	var failed bool
+	if parallel <= 1 {
+		for _, t := range tasks {
+			if err := executeTask(t, workspaceRoot, dryRun); err != nil {
+				slog.Error("task failed", "task", t.ID, "error", err)
+				failed = true
+			}
+		}
+	} else {
+		failed = runParallel(tasks, workspaceRoot, dryRun, parallel)
+	}
+
+	fmt.Println("==========================================")
+	fmt.Println("All tasks complete.")
+	fmt.Println("==========================================")
+
+	if failed {
+		return fmt.Errorf("one or more tasks failed")
+	}
+	return nil
 }
 
 func executeTask(t *task.Task, workspaceRoot string, dryRun bool) error {
@@ -117,186 +139,166 @@ func executeTask(t *task.Task, workspaceRoot string, dryRun bool) error {
 		return fmt.Errorf("building prompt: %w", err)
 	}
 
-	debugDir := debugDirForTask(t.ID)
-	if debugDir != "" {
-		if err := os.WriteFile(filepath.Join(debugDir, "prompt.md"), []byte(taskPrompt), 0644); err != nil {
-			slog.Warn("failed to save debug prompt", "error", err)
-		}
-	}
-
-	if dryRun {
-		fmt.Println()
-		fmt.Println("=== DRY RUN: Generated Prompt ===")
-		fmt.Println(taskPrompt)
-		fmt.Println("=== END PROMPT ===")
-		fmt.Println()
-		fmt.Println("Would create worktrees in:", t.TargetRepos)
-		fmt.Printf("Would run: claude -p --max-turns %d\n", cfg.MaxTurns)
-		return nil
-	}
-
-	// Read PR labels
+	// Build labels CSV
 	labelsCSV := "minion"
 	if len(t.PRLabels) > 0 {
-		labelsCSV = ""
-		for i, l := range t.PRLabels {
-			if i > 0 {
-				labelsCSV += ","
-			}
-			labelsCSV += l
-		}
+		labelsCSV = strings.Join(t.PRLabels, ",")
+	}
+	labels := strings.Split(labelsCSV, ",")
+
+	def := pipeline.Def{
+		Name:            "task-runner",
+		TaskID:          t.ID,
+		WorkspaceRoot:   workspaceRoot,
+		TargetRepos:     t.TargetRepos,
+		PromptText:      taskPrompt,
+		MaxTurns:        cfg.MaxTurns,
+		AllowedTools:    "Edit,Write,Read,Glob,Grep,Bash",
+		RunChecks:       true,
+		RetryOnFail:     true,
+		RetryMaxTurns:   15,
+		CreatePR:        true,
+		PRLabels:        labels,
+		TaskTitle:       t.Title,
+		TaskDescription: t.Description,
+		TaskWhy:         t.Why,
+		DryRun:          dryRun,
+		DebugDir:        debugDirForTask(t.ID),
 	}
 
-	// Create worktrees
-	fmt.Println("--- Creating worktrees ---")
-	var worktreePaths []string
-	var worktreeRepos []string
-	for _, repo := range t.TargetRepos {
-		repoPath := filepath.Join(workspaceRoot, repo)
-		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
-			slog.Warn("repo not found, skipping", "path", repoPath)
-			continue
-		}
-		wtPath, err := worktree.Create(repoPath, t.ID)
-		if err != nil {
-			return fmt.Errorf("creating worktree for %s: %w", repo, err)
-		}
-		worktreePaths = append(worktreePaths, wtPath)
-		worktreeRepos = append(worktreeRepos, repo)
-		fmt.Printf("Created worktree: %s\n", wtPath)
-	}
-
-	if len(worktreePaths) == 0 {
-		return fmt.Errorf("no worktrees created")
-	}
-
-	// Create virtual workspace directory with symlinks to worktrees
-	virtualWS, err := os.MkdirTemp("", "minion-workspace-*")
+	result, err := pipeline.Execute(def)
 	if err != nil {
-		return fmt.Errorf("creating virtual workspace: %w", err)
-	}
-	defer os.RemoveAll(virtualWS)
-
-	for i, repo := range worktreeRepos {
-		if err := os.Symlink(worktreePaths[i], filepath.Join(virtualWS, repo)); err != nil {
-			return fmt.Errorf("creating symlink for %s: %w", repo, err)
-		}
+		return err
 	}
 
-	// Run Claude Code
-	fmt.Println("--- Running Claude Code ---")
-	var logFile string
-	if debugDir != "" {
-		logFile = filepath.Join(debugDir, "claude-output.jsonl")
+	for _, url := range result.PRURLs {
+		fmt.Printf("PR: %s\n", url)
 	}
-	err = claude.Run(claude.Opts{
-		Prompt:   taskPrompt,
-		CWD:      virtualWS,
-		MaxTurns: cfg.MaxTurns,
-		LogFile:  logFile,
-	})
-	if err != nil {
-		slog.Warn("claude exited with error", "error", err)
-	}
-
-	// Check for changes before running checks
-	hasChanges := false
-	for i, wtPath := range worktreePaths {
-		status, _ := git.ExecGitDir(wtPath, "status", "--porcelain")
-		if strings.TrimSpace(status) != "" {
-			hasChanges = true
-			slog.Info("worktree has changes", "repo", worktreeRepos[i], "status", strings.TrimSpace(status))
-		} else {
-			slog.Info("worktree has no changes", "repo", worktreeRepos[i])
-		}
-	}
-	if !hasChanges {
-		slog.Warn("claude produced no changes in any repo")
-		cleanupWorktrees(t.TargetRepos, t.ID, workspaceRoot)
-		return fmt.Errorf("no changes produced for task %s", t.ID)
-	}
-
-	// Run checks
-	fmt.Println("--- Running checks ---")
-	allPass := true
-	var failedOutput string
-	for _, wtPath := range worktreePaths {
-		output, err := checks.Run(wtPath)
-		if err != nil {
-			allPass = false
-			failedOutput += output + "\n"
-		}
-	}
-
-	// Retry on failure
-	if !allPass {
-		fmt.Println("--- Checks failed, retrying with error feedback ---")
-		retryPrompt := fmt.Sprintf(`The following checks failed after your implementation. Please fix the issues:
-
-%s
-
-Fix the errors and ensure all checks pass. Do not introduce new changes beyond what's needed to fix the failures.`, failedOutput)
-
-		var retryLogFile string
-		if debugDir != "" {
-			retryLogFile = filepath.Join(debugDir, "claude-retry-output.jsonl")
-		}
-		_ = claude.Run(claude.Opts{
-			Prompt:   retryPrompt,
-			CWD:      virtualWS,
-			MaxTurns: 15,
-			LogFile:  retryLogFile,
-		})
-
-		// Re-run checks
-		fmt.Println("--- Re-running checks after retry ---")
-		allPass = true
-		for _, wtPath := range worktreePaths {
-			if _, err := checks.Run(wtPath); err != nil {
-				allPass = false
-			}
-		}
-
-		if !allPass {
-			slog.Error("checks still failing after retry, skipping PR creation")
-			cleanupWorktrees(t.TargetRepos, t.ID, workspaceRoot)
-			return fmt.Errorf("checks failed for task %s", t.ID)
-		}
-	}
-
-	// Create PRs
-	fmt.Println("--- Creating PRs ---")
-	prURLs, err := pr.CreateAndLinkAll(t.ID, t.Title, t.Description, t.Why, workspaceRoot, labelsCSV, t.TargetRepos)
-	if err != nil {
-		cleanupWorktrees(t.TargetRepos, t.ID, workspaceRoot)
-		return fmt.Errorf("PR creation failed: %w", err)
-	}
-	if len(prURLs) == 0 {
-		cleanupWorktrees(t.TargetRepos, t.ID, workspaceRoot)
-		return fmt.Errorf("no PRs created for task %s", t.ID)
-	}
-
-	if prURLsFile := os.Getenv("MINION_PR_URLS_FILE"); prURLsFile != "" {
-		if f, err := os.OpenFile(prURLsFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
-			for _, u := range prURLs {
-				fmt.Fprintln(f, u)
-			}
-			f.Close()
-		}
-	}
-
-	// Cleanup
-	fmt.Println("--- Cleaning up worktrees ---")
-	cleanupWorktrees(t.TargetRepos, t.ID, workspaceRoot)
-
 	fmt.Printf("\nDONE: %s\n\n", t.ID)
 	return nil
 }
 
-func cleanupWorktrees(repos []string, taskID, workspaceRoot string) {
-	for _, repo := range repos {
-		worktree.Cleanup(filepath.Join(workspaceRoot, repo), taskID)
+// runAgent loads an agent definition and executes it.
+func runAgent(agentName, prRef, contextJSON, workspaceRoot string, dryRun bool) error {
+	agentDef, err := agent.Load(agentName)
+	if err != nil {
+		return err
 	}
+
+	fmt.Println("==========================================")
+	fmt.Printf("AGENT: %s\n", agentDef.Name)
+	fmt.Printf("DESCRIPTION: %s\n", agentDef.Description)
+	fmt.Println("==========================================")
+
+	// Parse context JSON
+	vars := make(map[string]string)
+	if contextJSON != "" {
+		if err := json.Unmarshal([]byte(contextJSON), &vars); err != nil {
+			return fmt.Errorf("parsing --context JSON: %w", err)
+		}
+	}
+
+	// Parse --pr flag
+	var prRepo, prNumber, repoShort string
+	if prRef != "" {
+		parts := strings.SplitN(prRef, "#", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid PR reference: %s (expected owner/repo#number)", prRef)
+		}
+		prRepo = parts[0]
+		prNumber = parts[1]
+		repoShort = prRepo
+		if idx := strings.LastIndex(prRepo, "/"); idx >= 0 {
+			repoShort = prRepo[idx+1:]
+		}
+		vars["PR_REF"] = prRef
+		vars["PR_REPO"] = prRepo
+		vars["PR_NUMBER"] = prNumber
+	}
+
+	// Run context providers
+	if len(agentDef.ContextProviders) > 0 {
+		fmt.Println("--- Gathering context ---")
+		input := appcontext.ProviderInput{
+			PRRepo:        prRepo,
+			PRNumber:      prNumber,
+			WorkspaceRoot: workspaceRoot,
+			RepoShort:     repoShort,
+			PromptsDir:    filepath.Join(workspaceRoot, "minions", "prompts"),
+		}
+		if err := appcontext.RunProviders(agentDef.ContextProviders, input, vars); err != nil {
+			return err
+		}
+	}
+
+	// Determine target repos
+	targetRepos := agentDef.TargetRepos
+	if repoShort != "" && len(targetRepos) == 0 {
+		// For agents like readme-updater, the target repo is the PR's repo
+		targetRepos = []string{repoShort}
+	}
+
+	// Build task ID
+	taskID := agentDef.Name
+	if prRepo != "" && prNumber != "" {
+		taskID = fmt.Sprintf("%s-%s-%s", agentDef.Name, strings.ReplaceAll(prRepo, "/", "-"), prNumber)
+	}
+
+	// Build PR metadata
+	var commitMsg, prTitle, prBody, prRepoFull string
+	sourcePRTitle := vars["PR_TITLE"]
+	if sourcePRTitle == "" {
+		sourcePRTitle = "Unknown"
+	}
+
+	if len(targetRepos) == 1 && prRepo != "" {
+		prRepoFull = prRepo
+		if agentDef.Name == "doc-updater" {
+			prRepoFull = "partio-io/docs"
+		}
+
+		commitMsg = fmt.Sprintf("docs: update for %s#%s\n\nAutomated by partio-io/minions (%s).\nSource PR: %s#%s\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+			prRepo, prNumber, agentDef.Name, prRepo, prNumber)
+
+		prTitle = fmt.Sprintf("[%s] Update for %s#%s: %s", agentDef.Name, prRepo, prNumber, sourcePRTitle)
+
+		prBody = fmt.Sprintf("## Summary\n\nAutomated update for %s#%s.\n\n**Source PR:** https://github.com/%s/pull/%s\n\n---\n\n*This PR was created by the %s. Please review carefully.*",
+			prRepo, prNumber, prRepo, prNumber, agentDef.Name)
+	}
+
+	opts := agent.PipelineOpts{
+		TaskID:         taskID,
+		WorkspaceRoot:  workspaceRoot,
+		TargetRepos:    targetRepos,
+		CommitMsg:      commitMsg,
+		PRTitle:        prTitle,
+		PRBody:         prBody,
+		PRRepo:         prRepoFull,
+		SourcePRRepo:   prRepo,
+		SourcePRNumber: prNumber,
+		DryRun:         dryRun,
+		DebugDir:       debugDirForTask(taskID),
+	}
+
+	if cfg.MaxTurns > 0 && cfg.MaxTurns < agentDef.MaxTurns {
+		opts.MaxTurns = cfg.MaxTurns
+	}
+
+	def, err := agent.BuildPipelineDef(agentDef, vars, opts)
+	if err != nil {
+		return err
+	}
+
+	result, err := pipeline.Execute(*def)
+	if err != nil {
+		return err
+	}
+
+	for _, url := range result.PRURLs {
+		fmt.Printf("PR: %s\n", url)
+	}
+	fmt.Printf("\nDONE: %s\n\n", agentDef.Name)
+	return nil
 }
 
 func debugDirForTask(taskID string) string {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	appcontext "github.com/partio-io/minions/internal/context"
+	"github.com/partio-io/minions/internal/pipeline"
+	"github.com/partio-io/minions/internal/prompt"
+)
+
+//go:embed agents/*
+var agentDefs embed.FS
+
+// Def describes an agent type loaded from YAML.
+type Def struct {
+	Name             string                  `yaml:"name"`
+	Description      string                  `yaml:"description"`
+	PromptTemplate   string                  `yaml:"prompt_template"`
+	TargetRepos      []string                `yaml:"target_repos"`
+	MaxTurns         int                     `yaml:"max_turns"`
+	AllowedTools     string                  `yaml:"allowed_tools"`
+	RunChecks        bool                    `yaml:"checks"`
+	CreatePR         bool                    `yaml:"create_pr"`
+	PRLabels         []string                `yaml:"pr_labels"`
+	SkipMarker       string                  `yaml:"skip_marker"`
+	RetryOnFail      bool                    `yaml:"retry_on_fail"`
+	RetryMaxTurns    int                     `yaml:"retry_max_turns"`
+	StageFiles       []string                `yaml:"stage_files"`
+	ContextProviders []appcontext.ProviderDef `yaml:"context_providers"`
+}
+
+// Load loads an agent definition by name from the embedded agents directory.
+func Load(name string) (*Def, error) {
+	data, err := agentDefs.ReadFile("agents/" + name + ".yaml")
+	if err != nil {
+		return nil, fmt.Errorf("agent %q not found: %w", name, err)
+	}
+
+	var def Def
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return nil, fmt.Errorf("parsing agent %q: %w", name, err)
+	}
+
+	return &def, nil
+}
+
+// List returns the names of all available agent definitions.
+func List() ([]string, error) {
+	entries, err := agentDefs.ReadDir("agents")
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, ".yaml") {
+			names = append(names, strings.TrimSuffix(name, ".yaml"))
+		}
+	}
+	return names, nil
+}
+
+// BuildPipelineDef builds a pipeline.Def from an agent definition and context.
+// The vars map provides template variables gathered by context providers.
+// The opts provide runtime configuration (workspace root, task ID, dry run, etc.).
+func BuildPipelineDef(agentDef *Def, vars map[string]string, opts PipelineOpts) (*pipeline.Def, error) {
+	// Load and render the prompt template
+	tmpl, err := prompt.Template(agentDef.PromptTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("loading template %q: %w", agentDef.PromptTemplate, err)
+	}
+
+	promptText := RenderTemplate(tmpl, vars)
+
+	// Determine target repos
+	targetRepos := agentDef.TargetRepos
+	if len(opts.TargetRepos) > 0 {
+		targetRepos = opts.TargetRepos
+	}
+
+	def := &pipeline.Def{
+		Name:          agentDef.Name,
+		TaskID:        opts.TaskID,
+		WorkspaceRoot: opts.WorkspaceRoot,
+		TargetRepos:   targetRepos,
+		PromptText:    promptText,
+		MaxTurns:      agentDef.MaxTurns,
+		AllowedTools:  agentDef.AllowedTools,
+		SkipMarker:    agentDef.SkipMarker,
+		RunChecks:     agentDef.RunChecks,
+		RetryOnFail:   agentDef.RetryOnFail,
+		RetryMaxTurns: agentDef.RetryMaxTurns,
+		CreatePR:      agentDef.CreatePR,
+		PRLabels:      agentDef.PRLabels,
+		StageFiles:    agentDef.StageFiles,
+		CommitMsg:     opts.CommitMsg,
+		PRTitle:       opts.PRTitle,
+		PRBody:        opts.PRBody,
+		PRRepo:        opts.PRRepo,
+		TaskTitle:     opts.TaskTitle,
+		TaskDescription: opts.TaskDescription,
+		TaskWhy:       opts.TaskWhy,
+		SourcePRRepo:   opts.SourcePRRepo,
+		SourcePRNumber: opts.SourcePRNumber,
+		DryRun:        opts.DryRun,
+		DebugDir:      opts.DebugDir,
+	}
+
+	// Override max turns if opts specifies one
+	if opts.MaxTurns > 0 {
+		def.MaxTurns = opts.MaxTurns
+	}
+
+	return def, nil
+}
+
+// PipelineOpts holds runtime options not part of the agent definition.
+type PipelineOpts struct {
+	TaskID        string
+	WorkspaceRoot string
+	TargetRepos   []string // override agent's target repos
+	MaxTurns      int      // override agent's max turns (0 = use agent default)
+
+	// PR fields (pre-computed by the caller)
+	CommitMsg       string
+	PRTitle         string
+	PRBody          string
+	PRRepo          string
+	TaskTitle       string
+	TaskDescription string
+	TaskWhy         string
+	SourcePRRepo    string
+	SourcePRNumber  string
+
+	DryRun   bool
+	DebugDir string
+}
+
+// RenderTemplate substitutes {{VAR}} placeholders in a template with values from vars.
+func RenderTemplate(tmpl string, vars map[string]string) string {
+	result := tmpl
+	for k, v := range vars {
+		result = strings.ReplaceAll(result, "{{"+k+"}}", v)
+	}
+	return result
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestLoadBuiltinAgents(t *testing.T) {
+	agents := []string{"task-runner", "doc-updater", "readme-updater"}
+	for _, name := range agents {
+		def, err := Load(name)
+		if err != nil {
+			t.Fatalf("Load(%q): %v", name, err)
+		}
+		if def.Name != name {
+			t.Errorf("Load(%q).Name = %q, want %q", name, def.Name, name)
+		}
+		if def.PromptTemplate == "" {
+			t.Errorf("Load(%q).PromptTemplate is empty", name)
+		}
+		if def.MaxTurns == 0 {
+			t.Errorf("Load(%q).MaxTurns is 0", name)
+		}
+	}
+}
+
+func TestLoadNotFound(t *testing.T) {
+	_, err := Load("nonexistent")
+	if err == nil {
+		t.Fatal("Load(nonexistent) should return error")
+	}
+}
+
+func TestList(t *testing.T) {
+	names, err := List()
+	if err != nil {
+		t.Fatalf("List(): %v", err)
+	}
+	if len(names) < 3 {
+		t.Errorf("List() returned %d agents, want at least 3", len(names))
+	}
+
+	expected := map[string]bool{"task-runner": false, "doc-updater": false, "readme-updater": false}
+	for _, n := range names {
+		expected[n] = true
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("List() missing %q", name)
+		}
+	}
+}
+
+func TestRenderTemplate(t *testing.T) {
+	tmpl := "Hello {{NAME}}, you have {{COUNT}} items."
+	vars := map[string]string{
+		"NAME":  "World",
+		"COUNT": "42",
+	}
+	got := RenderTemplate(tmpl, vars)
+	want := "Hello World, you have 42 items."
+	if got != want {
+		t.Errorf("RenderTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTemplateUnusedVars(t *testing.T) {
+	tmpl := "Hello {{NAME}}"
+	vars := map[string]string{
+		"NAME":  "World",
+		"EXTRA": "unused",
+	}
+	got := RenderTemplate(tmpl, vars)
+	want := "Hello World"
+	if got != want {
+		t.Errorf("RenderTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTemplateMissingVars(t *testing.T) {
+	tmpl := "Hello {{NAME}}, count: {{COUNT}}"
+	vars := map[string]string{
+		"NAME": "World",
+	}
+	got := RenderTemplate(tmpl, vars)
+	want := "Hello World, count: {{COUNT}}"
+	if got != want {
+		t.Errorf("RenderTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestDocUpdaterHasContextProviders(t *testing.T) {
+	def, err := Load("doc-updater")
+	if err != nil {
+		t.Fatalf("Load(doc-updater): %v", err)
+	}
+	if len(def.ContextProviders) == 0 {
+		t.Error("doc-updater should have context providers")
+	}
+
+	providerTypes := make(map[string]bool)
+	for _, p := range def.ContextProviders {
+		providerTypes[p.Type] = true
+	}
+
+	for _, expected := range []string{"gh-pr-title", "gh-pr-body", "gh-pr-diff"} {
+		if !providerTypes[expected] {
+			t.Errorf("doc-updater missing context provider %q", expected)
+		}
+	}
+}
+
+func TestReadmeUpdaterConfig(t *testing.T) {
+	def, err := Load("readme-updater")
+	if err != nil {
+		t.Fatalf("Load(readme-updater): %v", err)
+	}
+	if def.RunChecks {
+		t.Error("readme-updater should not run checks")
+	}
+	if def.SkipMarker != ".no-update-needed" {
+		t.Errorf("readme-updater.SkipMarker = %q, want %q", def.SkipMarker, ".no-update-needed")
+	}
+	if len(def.StageFiles) != 1 || def.StageFiles[0] != "README.md" {
+		t.Errorf("readme-updater.StageFiles = %v, want [README.md]", def.StageFiles)
+	}
+}

--- a/internal/agent/agents/doc-updater.yaml
+++ b/internal/agent/agents/doc-updater.yaml
@@ -1,0 +1,21 @@
+name: doc-updater
+description: Updates docs when code PRs merge
+prompt_template: doc-prompt.md
+target_repos: [docs]
+max_turns: 20
+allowed_tools: "Edit,Write,Read,Glob,Grep,Bash"
+checks: true
+create_pr: true
+pr_labels: [minion, documentation]
+skip_marker: ".no-update-needed"
+retry_on_fail: true
+retry_max_turns: 10
+context_providers:
+  - type: gh-pr-title
+    into: PR_TITLE
+  - type: gh-pr-body
+    into: PR_DESCRIPTION
+  - type: gh-pr-diff
+    into: PR_DIFF
+  - type: docs-claude-md
+    into: DOCS_CLAUDE_MD

--- a/internal/agent/agents/readme-updater.yaml
+++ b/internal/agent/agents/readme-updater.yaml
@@ -1,0 +1,23 @@
+name: readme-updater
+description: Updates a repo's README based on a merged PR
+prompt_template: readme-prompt.md
+max_turns: 10
+allowed_tools: "Edit,Write,Read,Glob,Grep,Bash"
+checks: false
+create_pr: true
+pr_labels: [minion]
+skip_marker: ".no-update-needed"
+stage_files: [README.md]
+context_providers:
+  - type: gh-pr-title
+    into: PR_TITLE
+  - type: gh-pr-body
+    into: PR_DESCRIPTION
+  - type: gh-pr-diff
+    into: PR_DIFF
+  - type: custom-prompt
+    into: CUSTOM_PROMPT
+  - type: current-readme
+    into: CURRENT_README
+  - type: repo-claude-md
+    into: REPO_CLAUDE_MD

--- a/internal/agent/agents/task-runner.yaml
+++ b/internal/agent/agents/task-runner.yaml
@@ -1,0 +1,10 @@
+name: task-runner
+description: Executes task specs end-to-end with worktrees, checks, and PRs
+prompt_template: prompt.md
+max_turns: 30
+allowed_tools: "Edit,Write,Read,Glob,Grep,Bash"
+checks: true
+create_pr: true
+pr_labels: [minion]
+retry_on_fail: true
+retry_max_turns: 15

--- a/internal/claude/run.go
+++ b/internal/claude/run.go
@@ -13,10 +13,11 @@ import (
 
 // Opts configures a headless Claude Code invocation.
 type Opts struct {
-	Prompt   string
-	CWD      string
-	MaxTurns int
-	LogFile  string // If set, tee stdout to this file for debug observability
+	Prompt       string
+	CWD          string
+	MaxTurns     int
+	AllowedTools string // Comma-separated tool list. Defaults to "Edit,Write,Read,Glob,Grep,Bash".
+	LogFile      string // If set, tee stdout to this file for debug observability
 }
 
 // Run executes `claude -p` in headless mode with the given options.
@@ -25,9 +26,14 @@ func Run(opts Opts) error {
 		opts.MaxTurns = 30
 	}
 
+	allowedTools := opts.AllowedTools
+	if allowedTools == "" {
+		allowedTools = "Edit,Write,Read,Glob,Grep,Bash"
+	}
+
 	args := []string{
 		"-p", opts.Prompt,
-		"--allowedTools", "Edit,Write,Read,Glob,Grep,Bash",
+		"--allowedTools", allowedTools,
 		"--max-turns", strconv.Itoa(opts.MaxTurns),
 		"--output-format", "stream-json",
 		"--verbose",

--- a/internal/context/providers.go
+++ b/internal/context/providers.go
@@ -1,0 +1,84 @@
+package context
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ProviderInput holds the input for context providers.
+type ProviderInput struct {
+	PRRepo        string
+	PRNumber      string
+	WorkspaceRoot string
+	RepoShort     string // short repo name (e.g. "app" from "partio-io/app")
+	PromptsDir    string // directory for per-repo prompt files
+}
+
+// ProviderDef describes a context provider in an agent definition.
+type ProviderDef struct {
+	Type string `yaml:"type"`
+	Into string `yaml:"into"`
+}
+
+// RunProviders executes each provider and populates the vars map.
+func RunProviders(providers []ProviderDef, input ProviderInput, vars map[string]string) error {
+	for _, p := range providers {
+		val, err := runProvider(p.Type, input)
+		if err != nil {
+			return fmt.Errorf("context provider %q: %w", p.Type, err)
+		}
+		vars[p.Into] = val
+	}
+	return nil
+}
+
+func runProvider(providerType string, input ProviderInput) (string, error) {
+	switch providerType {
+	case "gh-pr-title":
+		return ghPRField(input.PRRepo, input.PRNumber, "title"), nil
+	case "gh-pr-body":
+		return ghPRField(input.PRRepo, input.PRNumber, "body"), nil
+	case "gh-pr-diff":
+		return ghPRDiff(input.PRRepo, input.PRNumber), nil
+	case "repo-claude-md":
+		return readFile(filepath.Join(input.WorkspaceRoot, input.RepoShort, "CLAUDE.md")), nil
+	case "docs-claude-md":
+		return readFile(filepath.Join(input.WorkspaceRoot, "docs", "CLAUDE.md")), nil
+	case "current-readme":
+		return readFile(filepath.Join(input.WorkspaceRoot, input.RepoShort, "README.md")), nil
+	case "custom-prompt":
+		path := filepath.Join(input.PromptsDir, "readme-"+input.RepoShort+".md")
+		return readFile(path), nil
+	default:
+		return "", fmt.Errorf("unknown context provider: %s", providerType)
+	}
+}
+
+func ghPRField(repo, number, field string) string {
+	cmd := exec.Command("gh", "pr", "view", number, "--repo", repo, "--json", field, "-q", "."+field)
+	out, err := cmd.Output()
+	if err != nil {
+		return "Unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func ghPRDiff(repo, number string) string {
+	cmd := exec.Command("gh", "pr", "diff", number, "--repo", repo)
+	out, err := cmd.Output()
+	if err != nil {
+		return "Unable to fetch diff"
+	}
+	return string(out)
+}
+
+func readFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,11 +7,12 @@ import (
 )
 
 // ExecGit runs a git command and returns trimmed stdout.
+// Uses CombinedOutput so git error messages (from stderr) are included in errors.
 func ExecGit(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return "", fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/ingest/generate.go
+++ b/internal/ingest/generate.go
@@ -22,6 +22,7 @@ type Feature struct {
 	Source             string   `json:"source" yaml:"source"`
 	Description        string   `json:"description" yaml:"description"`
 	Why                string   `json:"why" yaml:"why"`
+	UserRelevance      string   `json:"user_relevance" yaml:"user_relevance"`
 	TargetRepos        []string `json:"target_repos" yaml:"target_repos"`
 	ContextHints       []string `json:"context_hints" yaml:"context_hints"`
 	AcceptanceCriteria []string `json:"acceptance_criteria" yaml:"acceptance_criteria"`
@@ -91,6 +92,7 @@ type taskFileData struct {
 	SourceType         string   `yaml:"source_type"`
 	Description        string   `yaml:"description"`
 	Why                string   `yaml:"why"`
+	UserRelevance      string   `yaml:"user_relevance"`
 	TargetRepos        []string `yaml:"target_repos"`
 	ContextHints       []string `yaml:"context_hints"`
 	AcceptanceCriteria []string `yaml:"acceptance_criteria"`
@@ -105,6 +107,7 @@ func writeTaskFile(f Feature, sourceType, outputDir string) error {
 		SourceType:         sourceType,
 		Description:        f.Description,
 		Why:                f.Why,
+		UserRelevance:      f.UserRelevance,
 		TargetRepos:        f.TargetRepos,
 		ContextHints:       f.ContextHints,
 		AcceptanceCriteria: f.AcceptanceCriteria,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,354 @@
+package pipeline
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/partio-io/minions/internal/checks"
+	"github.com/partio-io/minions/internal/claude"
+	"github.com/partio-io/minions/internal/git"
+	"github.com/partio-io/minions/internal/pr"
+	"github.com/partio-io/minions/internal/worktree"
+)
+
+// Def configures a single pipeline execution.
+type Def struct {
+	// Identity
+	Name   string
+	TaskID string
+
+	// Worktree setup
+	WorkspaceRoot string
+	TargetRepos   []string
+
+	// Claude invocation
+	PromptText   string
+	MaxTurns     int
+	AllowedTools string // comma-separated, e.g. "Edit,Write,Read,Glob,Grep,Bash"
+
+	// Post-Claude checks
+	SkipMarker    string // file in worktree that signals "no work needed"
+	RunChecks     bool
+	RetryOnFail   bool
+	RetryMaxTurns int
+
+	// PR creation
+	CreatePR   bool
+	CommitMsg  string   // for single-repo: full commit message
+	PRTitle    string   // for single-repo: PR title
+	PRBody     string   // for single-repo: PR body
+	PRLabels   []string // labels to apply
+	PRRepo     string   // for single-repo: full repo name (e.g. "partio-io/docs")
+	StageFiles []string // for single-repo: specific files to stage; empty = git add -A
+
+	// Multi-repo task fields (used by pr.CreateAndLinkAll)
+	TaskTitle       string
+	TaskDescription string
+	TaskWhy         string
+
+	// Cross-linking
+	SourcePRRepo   string
+	SourcePRNumber string
+
+	// Control
+	DryRun   bool
+	DebugDir string
+}
+
+// Result holds the outcome of a pipeline execution.
+type Result struct {
+	PRURLs     []string
+	Skipped    bool
+	SkipReason string
+}
+
+// Execute runs the full pipeline: worktree -> claude -> checks -> PR.
+func Execute(def Def) (*Result, error) {
+	if def.AllowedTools == "" {
+		def.AllowedTools = "Edit,Write,Read,Glob,Grep,Bash"
+	}
+	if def.MaxTurns == 0 {
+		def.MaxTurns = 30
+	}
+
+	multiRepo := len(def.TargetRepos) > 1
+
+	// Save debug prompt
+	if def.DebugDir != "" {
+		os.MkdirAll(def.DebugDir, 0755)
+		_ = os.WriteFile(filepath.Join(def.DebugDir, "prompt.md"), []byte(def.PromptText), 0644)
+	}
+
+	if def.DryRun {
+		fmt.Println()
+		fmt.Println("=== DRY RUN: Generated Prompt ===")
+		fmt.Println(def.PromptText)
+		fmt.Println("=== END PROMPT ===")
+		fmt.Println()
+		fmt.Printf("Would create worktrees for: %v\n", def.TargetRepos)
+		fmt.Printf("Would run: claude -p --max-turns %d --allowedTools %s\n", def.MaxTurns, def.AllowedTools)
+		return &Result{}, nil
+	}
+
+	// Create worktrees
+	fmt.Println("--- Creating worktrees ---")
+	var worktreePaths []string
+	var worktreeRepos []string
+	for _, repo := range def.TargetRepos {
+		repoPath := filepath.Join(def.WorkspaceRoot, repo)
+		if _, err := os.Stat(repoPath); os.IsNotExist(err) {
+			if multiRepo {
+				slog.Warn("repo not found, skipping", "path", repoPath)
+				continue
+			}
+			return nil, fmt.Errorf("repo not found at %s", repoPath)
+		}
+		wtPath, err := worktree.Create(repoPath, def.TaskID)
+		if err != nil {
+			return nil, fmt.Errorf("creating worktree for %s: %w", repo, err)
+		}
+		worktreePaths = append(worktreePaths, wtPath)
+		worktreeRepos = append(worktreeRepos, repo)
+		fmt.Printf("Worktree: %s\n", wtPath)
+	}
+
+	if len(worktreePaths) == 0 {
+		return nil, fmt.Errorf("no worktrees created")
+	}
+
+	cleanup := func() {
+		for _, repo := range def.TargetRepos {
+			worktree.Cleanup(filepath.Join(def.WorkspaceRoot, repo), def.TaskID)
+		}
+	}
+
+	// Determine CWD for Claude
+	var claudeCWD string
+	if multiRepo {
+		virtualWS, err := os.MkdirTemp("", "minion-workspace-*")
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("creating virtual workspace: %w", err)
+		}
+		defer os.RemoveAll(virtualWS)
+
+		for i, repo := range worktreeRepos {
+			if err := os.Symlink(worktreePaths[i], filepath.Join(virtualWS, repo)); err != nil {
+				cleanup()
+				return nil, fmt.Errorf("creating symlink for %s: %w", repo, err)
+			}
+		}
+		claudeCWD = virtualWS
+	} else {
+		claudeCWD = worktreePaths[0]
+	}
+
+	// Run Claude
+	fmt.Println("--- Running Claude Code ---")
+	var logFile string
+	if def.DebugDir != "" {
+		logFile = filepath.Join(def.DebugDir, "claude-output.jsonl")
+	}
+	err := claude.Run(claude.Opts{
+		Prompt:       def.PromptText,
+		CWD:          claudeCWD,
+		MaxTurns:     def.MaxTurns,
+		AllowedTools: def.AllowedTools,
+		LogFile:      logFile,
+	})
+	if err != nil {
+		slog.Warn("claude exited with error", "error", err)
+	}
+
+	// Check skip marker
+	if def.SkipMarker != "" {
+		for _, wtPath := range worktreePaths {
+			markerPath := filepath.Join(wtPath, def.SkipMarker)
+			if data, err := os.ReadFile(markerPath); err == nil {
+				fmt.Printf("Claude determined no update is needed:\n%s\n", string(data))
+				cleanup()
+				return &Result{Skipped: true, SkipReason: strings.TrimSpace(string(data))}, nil
+			}
+		}
+	}
+
+	// Check for changes
+	hasChanges := false
+	for i, wtPath := range worktreePaths {
+		status, _ := git.ExecGitDir(wtPath, "status", "--porcelain")
+		if strings.TrimSpace(status) != "" {
+			hasChanges = true
+			slog.Info("worktree has changes", "repo", worktreeRepos[i])
+		} else {
+			slog.Info("worktree has no changes", "repo", worktreeRepos[i])
+		}
+	}
+	if !hasChanges {
+		fmt.Println("No changes produced.")
+		cleanup()
+		return &Result{Skipped: true, SkipReason: "no changes"}, nil
+	}
+
+	// Run checks
+	if def.RunChecks {
+		allPass, failedOutput := runChecks(worktreePaths)
+
+		if !allPass && def.RetryOnFail {
+			fmt.Println("--- Checks failed, retrying with error feedback ---")
+			retryMaxTurns := def.RetryMaxTurns
+			if retryMaxTurns == 0 {
+				retryMaxTurns = 15
+			}
+
+			var retryLogFile string
+			if def.DebugDir != "" {
+				retryLogFile = filepath.Join(def.DebugDir, "claude-retry-output.jsonl")
+			}
+
+			retryPrompt := fmt.Sprintf("The following checks failed after your implementation. Please fix the issues:\n\n%s\n\nFix the errors and ensure all checks pass. Do not introduce new changes beyond what's needed to fix the failures.", failedOutput)
+			_ = claude.Run(claude.Opts{
+				Prompt:       retryPrompt,
+				CWD:          claudeCWD,
+				MaxTurns:     retryMaxTurns,
+				AllowedTools: def.AllowedTools,
+				LogFile:      retryLogFile,
+			})
+
+			fmt.Println("--- Re-running checks after retry ---")
+			allPass, _ = runChecks(worktreePaths)
+		}
+
+		if !allPass {
+			slog.Error("checks still failing, skipping PR creation")
+			cleanup()
+			return nil, fmt.Errorf("checks failed for %s", def.TaskID)
+		}
+	}
+
+	// Create PRs
+	var prURLs []string
+	if def.CreatePR {
+		fmt.Println("--- Creating PRs ---")
+
+		if multiRepo {
+			labelsCSV := strings.Join(def.PRLabels, ",")
+			if labelsCSV == "" {
+				labelsCSV = "minion"
+			}
+			urls, err := pr.CreateAndLinkAll(def.TaskID, def.TaskTitle, def.TaskDescription, def.TaskWhy, def.WorkspaceRoot, labelsCSV, worktreeRepos)
+			if err != nil {
+				cleanup()
+				return nil, fmt.Errorf("PR creation failed: %w", err)
+			}
+			prURLs = urls
+		} else {
+			url, err := createSingleRepoPR(def, worktreePaths[0])
+			if err != nil {
+				cleanup()
+				return nil, err
+			}
+			if url != "" {
+				prURLs = append(prURLs, url)
+			}
+		}
+
+		if len(prURLs) == 0 {
+			cleanup()
+			return nil, fmt.Errorf("no PRs created for %s", def.TaskID)
+		}
+
+		// Write PR URLs to file if env var set
+		if prURLsFile := os.Getenv("MINION_PR_URLS_FILE"); prURLsFile != "" {
+			if f, err := os.OpenFile(prURLsFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
+				for _, u := range prURLs {
+					fmt.Fprintln(f, u)
+				}
+				f.Close()
+			}
+		}
+	}
+
+	// Cleanup
+	fmt.Println("--- Cleaning up ---")
+	cleanup()
+
+	return &Result{PRURLs: prURLs}, nil
+}
+
+func runChecks(worktreePaths []string) (bool, string) {
+	fmt.Println("--- Running checks ---")
+	allPass := true
+	var failedOutput string
+	for _, wtPath := range worktreePaths {
+		output, err := checks.Run(wtPath)
+		if err != nil {
+			allPass = false
+			failedOutput += output + "\n"
+		}
+	}
+	return allPass, failedOutput
+}
+
+func createSingleRepoPR(def Def, wtPath string) (string, error) {
+	branchName := "minion/" + def.TaskID
+
+	// Stage
+	if len(def.StageFiles) > 0 {
+		for _, f := range def.StageFiles {
+			if _, err := git.ExecGitDir(wtPath, "add", f); err != nil {
+				return "", fmt.Errorf("staging %s: %w", f, err)
+			}
+		}
+	} else {
+		if _, err := git.ExecGitDir(wtPath, "add", "-A"); err != nil {
+			return "", fmt.Errorf("staging changes: %w", err)
+		}
+	}
+
+	// Commit
+	if _, err := git.ExecGitDir(wtPath, "commit", "-m", def.CommitMsg); err != nil {
+		return "", fmt.Errorf("committing: %w", err)
+	}
+
+	// Push
+	if _, err := git.ExecGitDir(wtPath, "push", "-u", "origin", branchName); err != nil {
+		return "", fmt.Errorf("pushing: %w", err)
+	}
+
+	// Ensure labels exist
+	for _, l := range def.PRLabels {
+		create := exec.Command("gh", "label", "create", l, "--repo", def.PRRepo)
+		_ = create.Run()
+	}
+
+	// Create PR
+	args := []string{
+		"pr", "create",
+		"--repo", def.PRRepo,
+		"--head", branchName,
+		"--title", def.PRTitle,
+		"--body", def.PRBody,
+	}
+	for _, l := range def.PRLabels {
+		args = append(args, "--label", l)
+	}
+
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("creating PR: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	prURL := strings.TrimSpace(string(out))
+
+	// Cross-link to source PR
+	if def.SourcePRRepo != "" && def.SourcePRNumber != "" {
+		fmt.Println("--- Cross-linking PRs ---")
+		pr.CommentOnPR(def.SourcePRRepo, def.SourcePRNumber, fmt.Sprintf("Related PR: %s", prURL))
+	}
+
+	return prURL, nil
+}

--- a/internal/prompt/templates/doc-prompt.md
+++ b/internal/prompt/templates/doc-prompt.md
@@ -25,17 +25,25 @@ The docs repo is checked out at `docs/`. It uses Mintlify with MDX files.
 
 1. **Read the diff carefully.** Understand what changed and whether it affects user-facing behavior, CLI commands, configuration, or APIs.
 
-2. **Determine if docs need updating.** Not every code change requires doc updates. Skip if the change is purely internal (refactoring, test-only, CI changes).
+2. **Consider the source repo.** The docs primarily cover the **partio CLI** (Go). Different repos warrant different levels of doc scrutiny:
+   - **cli** — Most likely to affect docs (commands, data format, configuration, hooks, storage layout)
+   - **app** — The web dashboard is a *viewer* of CLI data. App-side type changes or UI features do NOT mean the CLI's data format changed. Only document if the docs already cover dashboard features.
+   - **docs** — Skip (self-referential)
+   - **site**, **extension** — Rarely need doc updates
 
-3. **If docs need updating:**
+   Be especially careful not to document app-side TypeScript types or API routes as changes to the CLI's checkpoint format or storage layout. The CLI is the source of truth for what data is stored.
+
+3. **Determine if docs need updating.** Not every code change requires doc updates. Skip if the change is purely internal (refactoring, test-only, CI changes).
+
+4. **If docs need updating:**
    - Read the relevant existing doc pages in `docs/`
    - Update existing pages rather than creating new ones when possible
    - If a new page is needed, add it to the navigation in `docs/mint.json`
    - Use Mintlify MDX components consistent with existing docs (`<Tabs>`, `<Card>`, `<Warning>`)
    - Ensure all MDX files have `title` and `description` frontmatter
 
-4. **Keep changes minimal and accurate.** Only document what the PR actually changes. Do not add speculative documentation.
+5. **Keep changes minimal and accurate.** Only document what the PR actually changes. Do not add speculative documentation. Do not document internal implementation details (TypeScript types, API routes, React components) as user-facing data format changes.
 
-5. **Match existing voice and style.** The docs are concise and technical. Use imperative mood for instructions.
+6. **Match existing voice and style.** The docs are concise and technical. Use imperative mood for instructions.
 
-6. **If no docs update is needed**, create a file at `docs/.no-update-needed` containing a one-line explanation of why.
+7. **If no docs update is needed**, create a file at `docs/.no-update-needed` containing a one-line explanation of why.

--- a/internal/prompt/templates/ingest-prompt.md
+++ b/internal/prompt/templates/ingest-prompt.md
@@ -29,6 +29,7 @@ For each feature idea, output a JSON object with these fields:
   "source": "reference to original (e.g., 'entireio/cli#373 (changelog 0.4.5)')",
   "description": "What Partio should implement, adapted for its own architecture and conventions. Be specific about the desired behavior.",
   "why": "Brief explanation of why this matters for Partio — what problem it solves or what value it adds for users.",
+  "user_relevance": "Why this change is relevant to Partio users — how it improves their experience, workflow, or the value they get from Partio.",
   "target_repos": ["cli", "docs"],
   "context_hints": ["cli/internal/relevant/path/"],
   "acceptance_criteria": ["specific testable criterion 1", "specific testable criterion 2"]

--- a/internal/propose/issue.go
+++ b/internal/propose/issue.go
@@ -62,6 +62,12 @@ func FormatIssueBody(f ingest.Feature, sourceName, sourceType string) string {
 		b.WriteString("\n\n")
 	}
 
+	if f.UserRelevance != "" {
+		b.WriteString("## User Relevance\n\n")
+		b.WriteString(f.UserRelevance)
+		b.WriteString("\n\n")
+	}
+
 	b.WriteString("## Source\n\n")
 	b.WriteString(fmt.Sprintf("- **Origin:** %s\n", f.Source))
 	b.WriteString(fmt.Sprintf("- **Detected from:** `%s`\n", sourceName))
@@ -104,6 +110,7 @@ func embedTaskYAML(f ingest.Feature, sourceType string) string {
 		SourceType         string   `yaml:"source_type"`
 		Description        string   `yaml:"description"`
 		Why                string   `yaml:"why,omitempty"`
+		UserRelevance      string   `yaml:"user_relevance,omitempty"`
 		TargetRepos        []string `yaml:"target_repos"`
 		ContextHints       []string `yaml:"context_hints"`
 		AcceptanceCriteria []string `yaml:"acceptance_criteria"`
@@ -115,6 +122,7 @@ func embedTaskYAML(f ingest.Feature, sourceType string) string {
 		SourceType:         sourceType,
 		Description:        f.Description,
 		Why:                f.Why,
+		UserRelevance:      f.UserRelevance,
 		TargetRepos:        f.TargetRepos,
 		ContextHints:       f.ContextHints,
 		AcceptanceCriteria: f.AcceptanceCriteria,

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -10,6 +10,7 @@ type Task struct {
 	SourceType         string   `yaml:"source_type"`
 	Description        string   `yaml:"description"`
 	Why                string   `yaml:"why"`
+	UserRelevance      string   `yaml:"user_relevance"`
 	TargetRepos        []string `yaml:"target_repos"`
 	ContextHints       []string `yaml:"context_hints"`
 	AcceptanceCriteria []string `yaml:"acceptance_criteria"`

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -45,6 +45,9 @@ func Create(repoPath, taskID string) (string, error) {
 	if _, err := git.ExecGitDir(wtPath, "config", "user.email", "minion[bot]@users.noreply.github.com"); err != nil {
 		return "", fmt.Errorf("configuring git user.email: %w", err)
 	}
+	if _, err := git.ExecGitDir(wtPath, "config", "commit.gpgsign", "false"); err != nil {
+		return "", fmt.Errorf("configuring commit.gpgsign: %w", err)
+	}
 
 	return wtPath, nil
 }


### PR DESCRIPTION
* Objective

Resolve a workflow issue caused by issue title injection and remove the scheduled auto-approve configuration.

* Why

Inline ${{ }} interpolation allowed backticks in issue titles to be interpreted as bash command substitution. The cron schedule in approve.yml also enabled automatic approvals without manual review.

* How

Pass the issue title through an environment variable instead of inline interpolation to prevent command substitution. Remove the cron schedule from approve.yml so proposals require manual approval via workflow_dispatch.