### PR TITLE
Strip Minions to program runtime with --issue support

### DIFF
--- a/cmd/minions/run.go
+++ b/cmd/minions/run.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,15 +20,18 @@ import (
 
 func newRunCmd() *cobra.Command {
 	var dryRun bool
+	var issueRef string
 
 	cmd := &cobra.Command{
 		Use:   "run <program.md>",
 		Short: "Execute a program",
-		Long: `Execute an .md program file.
+		Long: `Execute an .md program file, optionally with a GitHub issue as context.
 
 Examples:
-  minions run programs/detect-hooks.md
-  minions run .minions/programs/my-feature.md --dry-run`,
+  minions run .minions/programs/implement.md --issue 120
+  minions run .minions/programs/implement.md --issue partio-io/cli#120
+  minions run .minions/programs/propose.md
+  minions run .minions/programs/implement.md --issue 120 --dry-run`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -44,13 +49,50 @@ Examples:
 				workspaceRoot = filepath.Dir(wd)
 			}
 
-			return runProgram(ctx, args[0], workspaceRoot, dryRun)
+			// Fetch issue context if --issue is provided
+			var issueContext string
+			if issueRef != "" {
+				var err error
+				issueContext, err = fetchIssue(issueRef)
+				if err != nil {
+					return fmt.Errorf("fetching issue: %w", err)
+				}
+			}
+
+			return runProgram(ctx, args[0], workspaceRoot, issueContext, dryRun)
 		},
 	}
 
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview generated prompt without executing")
+	cmd.Flags().StringVar(&issueRef, "issue", "", "GitHub issue number or reference (e.g., 120 or org/repo#120)")
 
 	return cmd
+}
+
+// fetchIssue fetches an issue's title and body via gh CLI.
+// Accepts either a bare number (uses principal repo) or a full reference (org/repo#123).
+func fetchIssue(ref string) (string, error) {
+	var repo, number string
+
+	if strings.Contains(ref, "#") {
+		parts := strings.SplitN(ref, "#", 2)
+		repo = parts[0]
+		number = parts[1]
+	} else {
+		// Bare number — use principal repo from project config
+		if proj == nil {
+			return "", fmt.Errorf("--issue with bare number requires project config (pass org/repo#number or ensure .minions/project.yaml exists)")
+		}
+		repo = proj.PrincipalFullName()
+		number = ref
+	}
+
+	cmd := exec.Command("gh", "issue", "view", number, "--repo", repo, "--json", "title,body", "--jq", `"# " + .title + "\n\n" + .body`)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh issue view %s --repo %s: %w", number, repo, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func debugDirForTask(taskID string) string {
@@ -63,7 +105,7 @@ func debugDirForTask(taskID string) string {
 	return dir
 }
 
-func runProgram(ctx context.Context, programPath, workspaceRoot string, dryRun bool) error {
+func runProgram(ctx context.Context, programPath, workspaceRoot, issueContext string, dryRun bool) error {
 	prog, err := program.LoadFile(programPath)
 	if err != nil {
 		return err
@@ -77,6 +119,9 @@ func runProgram(ctx context.Context, programPath, workspaceRoot string, dryRun b
 	fmt.Printf("TITLE: %s\n", prog.Title)
 	fmt.Printf("TARGET REPOS: %v\n", prog.AllTargetRepos())
 	fmt.Printf("AGENTS: %d\n", len(prog.Agents))
+	if issueContext != "" {
+		fmt.Println("ISSUE: provided")
+	}
 	fmt.Printf("DRY RUN: %v\n", dryRun)
 	fmt.Println("==========================================")
 
@@ -124,6 +169,7 @@ func runProgram(ctx context.Context, programPath, workspaceRoot string, dryRun b
 	result, err := executor.Run(ctx, executor.Opts{
 		Program:       prog,
 		PlanText:      planText,
+		IssueContext:  issueContext,
 		WorkspaceRoot: workspaceRoot,
 		Project:       proj,
 		Tracker:       tracker,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -24,6 +24,7 @@ import (
 type Opts struct {
 	Program       *program.Program
 	PlanText      string
+	IssueContext  string // fetched issue body, injected into prompt
 	WorkspaceRoot string
 	Project       *project.Project
 	Tracker       *pcontext.Tracker
@@ -96,7 +97,7 @@ func runAgent(ctx gocontext.Context, opts Opts, prog *program.Program, agent *pr
 	pt := opts.Tracker.StartPhase("agent:" + agent.Name)
 
 	// Build prompt
-	promptText := buildAgentPrompt(prog, agent, opts.PlanText, opts.WorkspaceRoot, opts.Project, pt)
+	promptText := buildAgentPrompt(prog, agent, opts.PlanText, opts.IssueContext, opts.WorkspaceRoot, opts.Project, pt)
 
 	if opts.DryRun {
 		fmt.Printf("\n=== DRY RUN: Agent %s Prompt ===\n", agent.Name)

--- a/internal/executor/prompt.go
+++ b/internal/executor/prompt.go
@@ -13,7 +13,7 @@ import (
 )
 
 // buildAgentPrompt constructs the prompt for a sub-agent execution.
-func buildAgentPrompt(prog *program.Program, agent *program.AgentDef, planText, workspaceRoot string, proj *project.Project, pt *context.PhaseTracker) string {
+func buildAgentPrompt(prog *program.Program, agent *program.AgentDef, planText, issueContext, workspaceRoot string, proj *project.Project, pt *context.PhaseTracker) string {
 	var b strings.Builder
 	repos := prog.EffectiveTargetRepos(agent)
 
@@ -21,6 +21,13 @@ func buildAgentPrompt(prog *program.Program, agent *program.AgentDef, planText, 
 	header := fmt.Sprintf("# Minion Task: %s\n\nYou are a coding agent executing a task autonomously. Complete the task in a single session without human interaction.\n\n", prog.Title)
 	b.WriteString(header)
 	pt.AddContext("template:header", header)
+
+	// Issue context (from --issue flag)
+	if issueContext != "" {
+		issueSection := "## Issue\n\n" + issueContext + "\n\n"
+		b.WriteString(issueSection)
+		pt.AddContext("issue", issueContext)
+	}
 
 	// Plan context
 	if planText != "" {


### PR DESCRIPTION
* Objective

Reduce Minions to a minimal program runtime and add --issue support to the run command.

* Why

Removing unused commands simplifies the CLI surface area and reduces maintenance overhead.

Feature-specific logic should live in .md programs within the host project rather than inside the CLI.

* How

Remove the plan, ingest, doc, readme, propose, and approve commands along with their supporting packages.

Limit Minions to three commands: run, init, and version.

Extend the run command with --issue to fetch a GitHub issue body and inject it into the program prompt.

Accept a bare number (resolved via project config) or a full org/repo#123 reference.