### PR TITLE
Detect Both Uncommitted and Committed Changes from Claude

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -223,13 +223,21 @@ func runAgent(ctx gocontext.Context, opts Opts, prog *program.Program, agent *pr
 		}
 	}
 
-	// Check for changes
+	// Check for changes — both uncommitted and committed
 	hasChanges := false
 	for i, wtPath := range worktreePaths {
+		// Check uncommitted changes
 		status, _ := git.ExecGitDir(wtPath, "status", "--porcelain")
 		if strings.TrimSpace(status) != "" {
 			hasChanges = true
-			slog.Info("worktree has changes", "agent", agent.Name, "repo", worktreeRepos[i])
+			slog.Info("worktree has uncommitted changes", "agent", agent.Name, "repo", worktreeRepos[i])
+			continue
+		}
+		// Check if there are new commits on the worktree branch vs the base
+		log, _ := git.ExecGitDir(wtPath, "log", "HEAD", "--not", "--remotes", "--oneline")
+		if strings.TrimSpace(log) != "" {
+			hasChanges = true
+			slog.Info("worktree has new commits", "agent", agent.Name, "repo", worktreeRepos[i])
 		}
 	}
 	if !hasChanges {

--- a/internal/pr/create.go
+++ b/internal/pr/create.go
@@ -17,27 +17,35 @@ type CreateOpts struct {
 }
 
 // Create stages, commits, pushes, and creates a PR for a minion's work.
+// Handles both uncommitted changes (stages + commits) and pre-committed changes (just pushes).
 // principalRepo is the full name of the principal repo (used in commit messages/PR bodies).
 // Returns the PR URL or empty string if no changes.
 func Create(worktreePath, repoFullName, taskID, title, description, why string, labels []string, principalRepo string, opts *CreateOpts) (string, error) {
-	// Check for changes
+	branchName := "minion/" + taskID
+
+	// Check for uncommitted changes
 	status, _ := git.ExecGitDir(worktreePath, "status", "--porcelain")
-	if strings.TrimSpace(status) == "" {
+	hasUncommitted := strings.TrimSpace(status) != ""
+
+	// Check for new commits (Claude may have committed already)
+	logOut, _ := git.ExecGitDir(worktreePath, "log", "HEAD", "--not", "--remotes", "--oneline")
+	hasNewCommits := strings.TrimSpace(logOut) != ""
+
+	if !hasUncommitted && !hasNewCommits {
 		slog.Info("no changes", "repo", filepath.Base(worktreePath))
 		return "", nil
 	}
 
-	branchName := "minion/" + taskID
+	// Stage and commit only if there are uncommitted changes
+	if hasUncommitted {
+		if _, err := git.ExecGitDir(worktreePath, "add", "-A"); err != nil {
+			return "", fmt.Errorf("staging changes: %w", err)
+		}
 
-	// Stage all changes
-	if _, err := git.ExecGitDir(worktreePath, "add", "-A"); err != nil {
-		return "", fmt.Errorf("staging changes: %w", err)
-	}
-
-	// Commit
-	commitMsg := fmt.Sprintf("%s\n\nAutomated by %s (task: %s)\n\nCo-Authored-By: Claude <noreply@anthropic.com>", title, principalRepo, taskID)
-	if _, err := git.ExecGitDir(worktreePath, "commit", "-m", commitMsg); err != nil {
-		return "", fmt.Errorf("committing changes: %w", err)
+		commitMsg := fmt.Sprintf("%s\n\nAutomated by %s (task: %s)\n\nCo-Authored-By: Claude <noreply@anthropic.com>", title, principalRepo, taskID)
+		if _, err := git.ExecGitDir(worktreePath, "commit", "-m", commitMsg); err != nil {
+			return "", fmt.Errorf("committing changes: %w", err)
+		}
 	}
 
 	// Push


### PR DESCRIPTION
* Objective

Enhance change detection to identify both uncommitted and committed changes made by Claude during a session.

* Why

Previously, only uncommitted changes were detected using `git status --porcelain`. If Claude created commits during the session, they were not recognized. This update ensures new commits are detected using
`git log HEAD --not --remotes`, preventing missed changes and ensuring accurate PR creation.

* How

The executor and PR creator now check for new commits in addition to uncommitted changes.

During PR creation, the stage and commit steps are skipped if Claude has already committed changes, and the branch is pushed directly.

A second Claude call is added after implementation to summarize the diff into a proper PR title and description.