### PR TITLE
Fix: set bypassPermissions mode for Claude execution

### DIFF
--- a/internal/claude/run.go
+++ b/internal/claude/run.go
@@ -104,6 +104,15 @@ func Run(ctx context.Context, opts Opts) (*Result, error) {
 		"subtype", result.Subtype,
 	)
 
+	if result.ResultText != "" {
+		// Log first 500 chars of result text for debugging
+		preview := result.ResultText
+		if len(preview) > 500 {
+			preview = preview[:500] + "..."
+		}
+		slog.Info("claude result text", "preview", preview)
+	}
+
 	// Write result to log file for debug observability
 	if opts.LogFile != "" {
 		if data, err := json.Marshal(resultMsg); err == nil {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -181,13 +181,14 @@ func runAgent(ctx gocontext.Context, opts Opts, prog *program.Program, agent *pr
 	}
 
 	result, err := claude.Run(ctx, claude.Opts{
-		Prompt:       promptText,
-		CWD:          claudeCWD,
-		MaxTurns:     maxTurns,
-		AllowedTools: strings.Join(tools, ","),
-		MaxBudgetUSD: agent.MaxBudgetUSD,
-		MCPServers:   mcpServers,
-		LogFile:      logFile,
+		Prompt:         promptText,
+		CWD:            claudeCWD,
+		MaxTurns:       maxTurns,
+		AllowedTools:   strings.Join(tools, ","),
+		PermissionMode: "bypassPermissions",
+		MaxBudgetUSD:   agent.MaxBudgetUSD,
+		MCPServers:     mcpServers,
+		LogFile:        logFile,
 	})
 	if err != nil {
 		cleanup()


### PR DESCRIPTION
## Objective

Enable Claude to write files, edit code, and run commands during
agent execution.

## Why

Without a permission mode set, Claude Code defaults to prompting
for user confirmation before any write/edit/bash operation. In
headless SDK mode, these prompts are silently denied — so Claude
could only read files for all 59+ turns, never writing anything.

This was the root cause of all "no changes" failures.

## How

Set PermissionMode to "bypassPermissions" in the executor's Claude
invocation. Also added result text logging for debugging.