### PR TITLE
Add research-minion PRD and vertical-slice issue breakdown

### DIFF
--- a/docs/2026-05-05-research-minion/issues.md
+++ b/docs/2026-05-05-research-minion/issues.md
@@ -1,0 +1,12 @@
+# Issues — 2026-05-05-research-minion
+
+Source: [prd.md](./prd.md)
+
+| Done | # | Title | Blocked by |
+|------|---|-------|------------|
+| [ ]  | 1 | [Workflow skeleton — label fires workflow, posts a stub comment](./issues/01-workflow-skeleton.md) | None |
+| [ ]  | 2 | [Researcher + persona produce a Q&A transcript](./issues/02-researcher-persona-transcript.md) | [#1](./issues/01-workflow-skeleton.md) |
+| [ ]  | 3 | [prd-writer agent + PRD comment + parent label](./issues/03-prd-writer-comment-label.md) | [#2](./issues/02-researcher-persona-transcript.md) |
+| [ ]  | 4 | [slicer agent + child issues + status comment](./issues/04-slicer-child-issues.md) | [#3](./issues/03-prd-writer-comment-label.md) |
+| [ ]  | 5 | [Idempotency — re-runs skip existing artifacts](./issues/05-idempotency-rerun-skip.md) | [#4](./issues/04-slicer-child-issues.md) |
+| [ ]  | 6 | [First production smoke run](./issues/06-production-smoke-run.md) | [#5](./issues/05-idempotency-rerun-skip.md) |

--- a/docs/2026-05-05-research-minion/issues/01-workflow-skeleton.md
+++ b/docs/2026-05-05-research-minion/issues/01-workflow-skeleton.md
@@ -1,0 +1,114 @@
+# 01 — Workflow skeleton: label fires workflow, posts a stub comment
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: None — can start immediately
+
+## What to build
+
+A new minion path on `partio-io/cli` that fires when a parent issue is
+labeled `minion-research` (or commented `/minion research`). The
+workflow clones `jcleira/argos` into the runner workspace, then runs
+`minions run .minions/programs/research.md --issue <N>`. At this slice,
+`research.md` contains a single trivial agent that uses `gh` to post a
+"research started — run-id `<sha7>`" comment on the parent issue and
+exit. No PRD, no children, no further sub-agents yet.
+
+This is the tracer bullet: it proves the wire end-to-end (label →
+workflow trigger → author_association gate → argos clone via PAT →
+minions runtime → multi-agent program parsing → gh side effect on
+issue) before any real research logic is added.
+
+The existing simple-task flow on `minion.yml` and the `propose.yml`
+cron are not modified.
+
+## Acceptance criteria
+
+- [ ] Three new labels exist on `partio-io/cli`: `minion-research`,
+  `minion-research-output`, `minion-research-completed`. Colors and
+  descriptions follow the existing minion-label convention in the
+  repo.
+- [ ] `secrets.GH_PAT` on `partio-io/cli` is scoped to read
+  `jcleira/argos` (private repo). Verified by a successful clone in a
+  workflow run.
+- [ ] `.github/workflows/research.yml` exists on `partio-io/cli` with:
+  - Triggers: `issues.labeled` (gated to `minion-research`), and
+    `issue_comment.created` (gated to body containing
+    `/minion research`).
+  - Job-level `if:` gate enforcing
+    `github.event.issue.author_association` (or
+    `github.event.comment.author_association`) in
+    `[OWNER, MEMBER, COLLABORATOR]`. Triggers from anyone else are
+    silently skipped.
+  - `runs-on: github-runner-partio-minion-ai-01` (same self-hosted
+    runner as `minion.yml`).
+  - `timeout-minutes: 90`.
+  - A step that clones `git@github.com:jcleira/argos.git` (master
+    branch) into `${{ github.workspace }}/argos/` using
+    `secrets.GH_PAT`.
+  - Reuses the existing `Install minions` step pattern (go install
+    `github.com/partio-io/minions/cmd/minions@<pinned-version>`).
+  - A step that runs `minions run .minions/programs/research.md
+    --issue ${{ github.event.issue.number }}` with `GH_TOKEN:
+    secrets.GH_PAT`.
+  - A `failure()` step that adds `minion-failed` label and posts a
+    comment with the run URL — same pattern as `minion.yml`'s "Mark
+    failed" step.
+  - **No** "Mark done" / auto-close step (the parent must stay open
+    after a successful research run).
+- [ ] `.minions/programs/research.md` exists with:
+  - Frontmatter declaring `id: research`, `target_repos: [cli]`. No
+    `acceptance_criteria` and no `pr_labels` (the run produces no PR).
+  - A single `## Agents` block containing one agent (e.g., `stub`)
+    whose prompt uses `gh issue comment` to post a one-line "research
+    started — run-id `<sha7>`" message on the parent issue, where
+    `<sha7>` is derived from the issue's events or the workflow run
+    id.
+- [ ] Smoke run: a test issue on `partio-io/cli` labeled
+  `minion-research` causes the workflow to fire, the workflow log
+  shows the argos clone step succeeding (and prints the argos SHA),
+  and a comment from the runner appears on the parent issue.
+- [ ] `minion.yml`, `propose.yml`, `propose.md`, `implement.md`,
+  `approve.md`, `doc-update.md`, `readme-update.md`, `ingest.md` are
+  not modified. The Go binary in `partio-minions` is not modified.
+
+## Modules touched
+
+- `partio-io/cli/.github/workflows/research.yml` (new)
+- `partio-io/cli/.minions/programs/research.md` (new, stub form)
+- `partio-io/cli` repo labels (3 new)
+- `secrets.GH_PAT` configuration on `partio-io/cli` (manual GitHub UI
+  action)
+
+No changes to `github.com/partio-io/minions` (the Go runtime). This
+slice is purely additive at the workflow / program / config layer.
+
+## Test prior art
+
+- `partio-io/cli/.github/workflows/minion.yml` — model the new
+  workflow after this one. Specifically, mirror its "Install
+  minions", "Run program", and "Mark failed" step shape; diverge only
+  on the items called out in the PRD's
+  *Implementation Decisions / Module interfaces* section.
+- `partio-io/cli/.minions/programs/propose.md` and `approve.md` —
+  examples of programs that produce only `gh` side effects with no PR
+  output. No `pr_labels` and no `acceptance_criteria` in their
+  frontmatter; the run is treated as "no worktree changes" and is
+  marked skipped, not failed.
+- `partio-minions/internal/program/parse_test.go` — running
+  `minions run research.md --dry-run` exercises this parser and is
+  the only program-file validation needed.
+
+## Out of scope
+
+- Researcher / persona / prd-writer / slicer agents and the privacy
+  directive. Covered in slice [#2](./02-researcher-persona-transcript.md)
+  and beyond.
+- Idempotency markers on the stub comment. The stub comment is a
+  smoke marker only and will be replaced in slice
+  [#3](./03-prd-writer-comment-label.md).
+- A real PRD comment, child issues, or
+  `minion-research-completed` labeling — slices
+  [#3](./03-prd-writer-comment-label.md) and
+  [#4](./04-slicer-child-issues.md).
+- Tightening `author_association` on existing `minion.yml`. The PRD
+  flags this as worth doing eventually; it is NOT part of this slice.

--- a/docs/2026-05-05-research-minion/issues/02-researcher-persona-transcript.md
+++ b/docs/2026-05-05-research-minion/issues/02-researcher-persona-transcript.md
@@ -1,0 +1,115 @@
+# 02 — Researcher + persona produce a Q&A transcript
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [01 — Workflow skeleton](./01-workflow-skeleton.md)
+
+## What to build
+
+Replace the stub agent in `research.md` with the first two real
+sub-agents — `researcher` and `persona` — that together drive a
+realistic research interview against the parent issue.
+
+The `researcher` agent walks a decision tree in the style of the
+`/code-research` skill, asking one question at a time and writing it
+to `./research-transcript.md` in the worktree. It loops until it has
+enough information to hand off to the PRD writer (introduced in slice
+[#3](./03-prd-writer-comment-label.md)), at which point it writes a
+trailing `RESEARCH_COMPLETE` marker on its own line.
+
+The `persona` agent answers each unanswered question in the
+transcript as jcleira would. Its prompt loads the full TELOS and
+memory substrate from the argos clone created in slice
+[#1](./01-workflow-skeleton.md) (`argos/telos/MISSION.md`,
+`argos/telos/GOALS.md`, `argos/telos/PROJECTS.md`,
+`argos/telos/BELIEFS.md`, all of `argos/memory/*.md` — currently 48
+files, ~120K chars). The agent decides at runtime which substrate is
+relevant per question; no curation or filtering happens at write
+time.
+
+The persona prompt contains a literal, hard-coded privacy directive
+(see *Persona privacy directive* in the PRD). The directive is
+load-bearing — every persona output must be in its own words, framed
+as a decision, and must never quote or paraphrase health, training,
+diary, financial, location, or calendar content from the substrate.
+
+The two agents share `./research-transcript.md` and alternate: each
+turn, the running agent reads the latest transcript state and
+appends its block, then yields control. The agents loop until
+`RESEARCH_COMPLETE`.
+
+The publisher (still a single trailing agent at this slice) posts the
+full transcript file as a comment on the parent issue so the user can
+see what the researcher and persona produced. This comment is *not*
+the final PRD — that arrives in slice
+[#3](./03-prd-writer-comment-label.md). No idempotency marker is
+required on this transitional comment.
+
+## Acceptance criteria
+
+- [ ] `research.md`'s `## Agents` section declares `researcher`,
+  `persona`, and `publisher` agents in that sequential order.
+- [ ] `research.md` has a `## Context` section with hints for
+  `argos/telos/MISSION.md`, `argos/telos/GOALS.md`,
+  `argos/telos/PROJECTS.md`, `argos/telos/BELIEFS.md`, and
+  `argos/memory/*.md` (glob, not enumerated). The hints reference the
+  paths under `${{ github.workspace }}/argos/` produced by slice
+  [#1](./01-workflow-skeleton.md).
+- [ ] The `persona` agent prompt contains a literal directive that
+  reads, semantically: "Use TELOS and memory to *decide* — what
+  answer would jcleira give? Never quote, paraphrase, or reference
+  personal data (health, training, daily diary content, finances,
+  location, calendar) in any output. Output answers in your own
+  words, framed as decisions on the question at hand." Wording may be
+  tuned over time, but the directive must be present and load-bearing
+  in the prompt.
+- [ ] Transcript flow: `researcher` writes one numbered question per
+  turn to `./research-transcript.md`; `persona` reads the latest
+  unanswered question, appends an `## Answer` block, then yields. The
+  loop continues until `researcher` writes `RESEARCH_COMPLETE` on its
+  own line.
+- [ ] `publisher` reads `./research-transcript.md` and posts its
+  contents as a comment on the parent issue via `gh issue comment`.
+- [ ] On the same test issue used in slice
+  [#1](./01-workflow-skeleton.md), a labeled re-run produces a
+  comment containing realistic Q&A grounded in the parent issue's
+  topic.
+- [ ] Manual review of the comment confirms no personal data leak: no
+  Whoop/Garmin numbers, no diary excerpts, no calendar event names,
+  no financial figures, no specific location strings. The persona's
+  answers read as *decisions*, not as recitations of substrate.
+
+## Modules touched
+
+- `partio-io/cli/.minions/programs/research.md` (extend)
+
+No changes to `research.yml` (the workflow remains as built in slice
+[#1](./01-workflow-skeleton.md)). No changes to `partio-minions` Go
+runtime.
+
+## Test prior art
+
+- `~/.claude/skills/code-research/` (and the
+  `/home/arvos/.claude/skills/code-create-prd/` skill) — the
+  spiritual model for the researcher's interview style. The `argos`
+  repo's `skills/code-research/SKILL.md` is the closest direct
+  reference for question-tree shape.
+- `partio-cli/.minions/programs/propose.md` — example of a program
+  with a `## Context` section that lists files the agent should read.
+- `partio-cli/.minions/programs/implement.md` — example of an agent
+  block with `capabilities` (max_turns, retries). Multi-agent
+  programs declare multiple `### <agent>` blocks under `## Agents`.
+
+## Out of scope
+
+- The `prd-writer` agent and PRD comment formatting. Covered in slice
+  [#3](./03-prd-writer-comment-label.md).
+- The `slicer` agent and child issue creation. Covered in slice
+  [#4](./04-slicer-child-issues.md).
+- Idempotency markers on the transcript comment. The transcript
+  comment is transitional and will be replaced by the PRD comment in
+  slice [#3](./03-prd-writer-comment-label.md).
+- Automated regression tests scanning persona output for personal
+  data. The PRD flags this as a possible follow-up only if a real
+  leak is observed.
+- A "tune-up gotchas" file. Defer until persona misbehavior is
+  observed in real runs (PRD: *Out of Scope*).

--- a/docs/2026-05-05-research-minion/issues/03-prd-writer-comment-label.md
+++ b/docs/2026-05-05-research-minion/issues/03-prd-writer-comment-label.md
@@ -1,0 +1,90 @@
+# 03 — prd-writer agent + PRD comment + parent label
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [02 — Researcher + persona produce a Q&A transcript](./02-researcher-persona-transcript.md)
+
+## What to build
+
+Add a `prd-writer` sub-agent that runs after `researcher` + `persona`
+have produced `./research-transcript.md`. The writer reads the
+completed transcript and synthesizes a PRD body — the same shape the
+`/code-create-prd` skill produces (Problem Statement, Solution, User
+Stories, Implementation Decisions, Testing Decisions, Out of Scope,
+Further Notes). Output goes to `./prd-draft.md` in the worktree.
+
+The `publisher` agent (still trailing the chain) is upgraded:
+instead of posting the transcript as a comment, it now posts the
+contents of `./prd-draft.md` as a single comment on the parent issue.
+The first line of that comment is the idempotency marker
+`<!-- minion:research run-id=<sha7> -->`, where `<sha7>` is derived
+from the workflow's `github.run_id` or the issue's events (any stable
+per-run identifier).
+
+After posting the PRD comment, the publisher adds the
+`minion-research-completed` label to the parent issue. The publisher
+explicitly does NOT add `minion-done` and does NOT close the parent —
+the parent stays open until jcleira closes it manually.
+
+After this slice, a labeled run produces: real PRD body comment with
+marker, parent labeled `minion-research-completed`, parent open. Still
+no child issues — those arrive in slice
+[#4](./04-slicer-child-issues.md).
+
+## Acceptance criteria
+
+- [ ] `research.md`'s `## Agents` section declares `researcher`,
+  `persona`, `prd-writer`, `publisher` in that sequential order.
+- [ ] `prd-writer` reads `./research-transcript.md` and writes
+  `./prd-draft.md` in the worktree. The output follows the
+  `/code-create-prd` shape (Problem Statement, Solution, User
+  Stories, Implementation Decisions, Testing Decisions, Out of
+  Scope, Further Notes — section headings may be tuned but the
+  general structure must hold).
+- [ ] `publisher` posts `./prd-draft.md` content as a comment on the
+  parent issue via `gh issue comment`. The first line of the comment
+  body is exactly `<!-- minion:research run-id=<sha7> -->`, where
+  `<sha7>` is a stable seven-character identifier derived from the
+  current run.
+- [ ] `publisher` adds the `minion-research-completed` label to the
+  parent issue via `gh issue edit --add-label`.
+- [ ] `publisher` does NOT add `minion-done` to the parent and does
+  NOT call `gh issue close` on the parent.
+- [ ] The transcript-as-comment behavior from slice
+  [#2](./02-researcher-persona-transcript.md) is removed (replaced by
+  the PRD comment).
+- [ ] The privacy directive from slice
+  [#2](./02-researcher-persona-transcript.md) remains intact in the
+  `persona` agent prompt.
+- [ ] Manual review of the comment on the test issue confirms: a
+  real PRD body, the marker on line 1, parent labeled
+  `minion-research-completed`, parent issue state still `open`, no
+  personal data leaks.
+
+## Modules touched
+
+- `partio-io/cli/.minions/programs/research.md` (extend)
+
+No changes to `research.yml`. No changes to `partio-minions` Go
+runtime.
+
+## Test prior art
+
+- `~/.claude/skills/code-create-prd/` — the spiritual model for the
+  PRD shape and section headings.
+- The PRD this issue file ships against
+  ([../prd.md](../prd.md)) is itself the canonical example of the
+  output shape.
+- `partio-cli/.minions/programs/propose.md` — pattern for an agent
+  prompt that uses `gh` commands directly to mutate GitHub state.
+
+## Out of scope
+
+- The `slicer` agent, child issue creation, status comment on parent.
+  Covered in slice [#4](./04-slicer-child-issues.md).
+- Skip-if-marker-exists logic on the PRD comment. Markers are written
+  in this slice; the *check before write* logic lives in slice
+  [#5](./05-idempotency-rerun-skip.md).
+- PRD-comment versioning / history. PRD: *Out of Scope* — first
+  version is what's posted.
+- Automated parent-close when child PRs are merged. PRD: *Out of
+  Scope*.

--- a/docs/2026-05-05-research-minion/issues/04-slicer-child-issues.md
+++ b/docs/2026-05-05-research-minion/issues/04-slicer-child-issues.md
@@ -1,0 +1,109 @@
+# 04 — slicer agent + child issues + status comment
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [03 — prd-writer agent + PRD comment + parent label](./03-prd-writer-comment-label.md)
+
+## What to build
+
+Add a `slicer` sub-agent that runs between `prd-writer` and
+`publisher`. The slicer reads `./prd-draft.md` (produced in slice
+[#3](./03-prd-writer-comment-label.md)) and decomposes the PRD into
+vertical-slice descriptions, one block per slice. Output goes to
+`./slices.md` in the worktree. Each slice block contains: title,
+description (1–3 paragraphs of end-to-end behavior), acceptance
+criteria checklist, modules touched, and out-of-scope pointers — the
+same shape this issue file follows.
+
+The `publisher` is extended again. After posting the PRD comment and
+labeling the parent (slice [#3](./03-prd-writer-comment-label.md)), it
+now also opens one GitHub issue per slice on the same repo via
+`gh issue create`. Each child issue:
+
+- Is created with two labels: `minion-approved` (the existing trigger
+  for `minion.yml`, which fires `implement.md` automatically) and
+  `minion-research-output` (provenance, for filtering).
+- Has its body prefixed by exactly
+  `<!-- minion:slice parent=#<N> slice=<n>/<total> -->` on line 1,
+  where `<N>` is the parent issue number, `<n>` is the 1-indexed
+  slice ordinal, and `<total>` is the total slice count for this run.
+- Has a title derived from the slice's title field in `./slices.md`.
+- Has a body that includes the slice description, acceptance
+  criteria, modules touched, and a back-reference to the parent issue
+  (`Parent: #<N>`) so a fresh `implement.md` run on the child has
+  enough context.
+
+After all child issues are open, the publisher posts a final status
+comment on the parent issue listing the child issue numbers as
+clickable references (`#<child-N>`). The first line of that comment
+is exactly `<!-- minion:research-status parent=#<N> -->`.
+
+The auto-cascade is deliberate: each child issue's `minion-approved`
+label causes `minion.yml` to fire `implement.md` on that child, which
+opens a PR. No new wiring is needed between research and implement —
+they compose via the existing label.
+
+## Acceptance criteria
+
+- [ ] `research.md`'s `## Agents` section declares `researcher`,
+  `persona`, `prd-writer`, `slicer`, `publisher` in that sequential
+  order.
+- [ ] `slicer` reads `./prd-draft.md` and writes `./slices.md`. Each
+  slice block contains at minimum: title, description, acceptance
+  criteria checklist.
+- [ ] `publisher` opens one child issue per slice on
+  `partio-io/cli` via `gh issue create`, each with labels
+  `minion-approved` AND `minion-research-output`.
+- [ ] Each child issue body's first line is exactly
+  `<!-- minion:slice parent=#<N> slice=<n>/<total> -->` with the
+  correct values substituted.
+- [ ] Each child issue body contains the slice description,
+  acceptance criteria, modules touched, and a `Parent: #<N>`
+  back-reference.
+- [ ] `publisher` posts a final status comment on the parent issue
+  with first line exactly `<!-- minion:research-status parent=#<N> -->`,
+  and a body listing each child issue as `#<child-N>`.
+- [ ] Smoke run on the test issue from prior slices: PRD comment
+  appears, then N child issues open, then the status comment appears
+  listing those N children. Each child receives both labels.
+- [ ] Auto-cascade verification: at least one child issue is
+  observed to trigger `minion.yml` and produce a PR via
+  `implement.md` (or, if testing in isolation, the
+  `minion-approved` label is removed manually before the cascade
+  fires — mirroring the smoke procedure planned in slice
+  [#6](./06-production-smoke-run.md)).
+- [ ] Existing simple-task flow (`minion.yml` + `implement.md`) is
+  unchanged.
+
+## Modules touched
+
+- `partio-io/cli/.minions/programs/research.md` (extend)
+
+No changes to `research.yml`. No changes to `minion.yml`,
+`implement.md`, or any other existing program. No changes to
+`partio-minions` Go runtime.
+
+## Test prior art
+
+- `~/.claude/skills/code-create-issues/` — the spiritual model for
+  the slicer's vertical-slice shape.
+- This issue file (and its siblings under
+  `partio-minions/docs/2026-05-05-research-minion/issues/`) is
+  itself a worked example of the slice block shape the slicer should
+  emit.
+- `partio-cli/.minions/programs/propose.md` — pattern for using
+  `gh issue create` with labels from inside an agent prompt. The
+  propose program also writes a body marker
+  (`<!-- program: .minions/programs/<id>.md -->`) — the same idea,
+  same line-1 convention.
+
+## Out of scope
+
+- Skip-if-marker-exists logic on the PRD comment, child issues, and
+  status comment. Markers are written here; the *check before write*
+  logic lives in slice [#5](./05-idempotency-rerun-skip.md).
+- The first production smoke run against a real `minion-proposal`
+  issue. Covered in slice [#6](./06-production-smoke-run.md).
+- A failure-recovery path beyond the `minion-failed` label + run-URL
+  comment inherited from slice [#1](./01-workflow-skeleton.md). PRD:
+  *Out of Scope*.
+- Automated dashboards for child-PR success rate. PRD: *Out of Scope*.

--- a/docs/2026-05-05-research-minion/issues/05-idempotency-rerun-skip.md
+++ b/docs/2026-05-05-research-minion/issues/05-idempotency-rerun-skip.md
@@ -1,0 +1,106 @@
+# 05 — Idempotency: re-runs skip existing artifacts
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [04 — slicer agent + child issues + status comment](./04-slicer-child-issues.md)
+
+## What to build
+
+Make `research.md` safe to re-run against the same parent issue
+without producing duplicate artifacts. As of slice
+[#4](./04-slicer-child-issues.md), the publisher writes three kinds of
+GitHub artifacts, each tagged with a marker:
+
+- PRD comment on parent — first line
+  `<!-- minion:research run-id=<sha7> -->`
+- Child issue body — first line
+  `<!-- minion:slice parent=#<N> slice=<n>/<total> -->`
+- Status comment on parent — first line
+  `<!-- minion:research-status parent=#<N> -->`
+
+This slice extends the `publisher` agent's prompt so that, before
+each write, it queries existing GitHub state and skips the write if
+a matching marker already exists. Concretely:
+
+- Before posting the PRD comment, query
+  `gh issue view <N> --repo <repo> --json comments` and inspect each
+  comment body. If any comment's first line begins with
+  `<!-- minion:research run-id=` (any run-id), skip the write or
+  regenerate the comment in place via `gh issue comment edit` (the
+  prompt may pick either; the contract is "no duplicate"). Per the
+  PRD's *Idempotency contract* section: "regenerating instead" is
+  acceptable.
+- Before opening child issues, query
+  `gh issue list --repo <repo> --search 'in:body
+  <!-- minion:slice parent=#<N>'`. If matches exist, skip creating
+  child issues whose `slice=<n>/<total>` marker already appears, or
+  regenerate them in place.
+- Before posting the status comment, apply the same
+  query-and-skip-or-replace logic against the parent's existing
+  comments using the `minion:research-status parent=#<N>` marker.
+
+The intent is operational: a developer who re-labels a parent issue
+(or re-runs the workflow from the GitHub UI) gets a clean update
+rather than duplicates. The exact strategy (skip vs replace) is a
+publisher-prompt decision; what must hold is the no-duplicate
+invariant.
+
+## Acceptance criteria
+
+- [ ] `publisher` agent prompt instructs the agent to query existing
+  parent-issue comments via `gh issue view --json comments` before
+  posting the PRD comment, and to skip or replace if a comment with
+  the `minion:research run-id=` marker prefix already exists.
+- [ ] `publisher` agent prompt instructs the agent to query existing
+  child issues via `gh issue list --search` (or equivalent) using the
+  `minion:slice parent=#<N>` marker, and to skip or replace child
+  issues whose `slice=<n>/<total>` marker already exists for the
+  current parent.
+- [ ] `publisher` agent prompt instructs the agent to query existing
+  parent-issue comments for the
+  `minion:research-status parent=#<N>` marker before posting the
+  status comment, and to skip or replace if it already exists.
+- [ ] Re-run smoke: trigger the workflow twice on the same test
+  parent issue (e.g., remove and re-apply the `minion-research`
+  label, or trigger via comment after a previous run finished).
+  After the second run:
+  - Exactly one PRD comment exists on the parent (count by marker
+    prefix).
+  - The set of child issues for the parent has not grown (no
+    duplicates by `slice=<n>/<total>` marker).
+  - Exactly one status comment exists on the parent (count by
+    marker).
+- [ ] No regressions: a first run on a fresh test parent issue still
+  produces the full set of artifacts (PRD comment + N child issues +
+  status comment) — slice [#4](./04-slicer-child-issues.md) behavior
+  is preserved.
+
+## Modules touched
+
+- `partio-io/cli/.minions/programs/research.md` (extend
+  `publisher` prompt only)
+
+No changes to `research.yml`. No changes to `partio-minions` Go
+runtime.
+
+## Test prior art
+
+- `partio-cli/.minions/programs/propose.md` step 4 ("Check if a
+  proposal already exists: `gh issue list --repo <this-repo> --label
+  minion-proposal --search "<feature-id>" --limit 1`") — the same
+  pattern of query-existing-before-write, applied to
+  `minion-proposal` issues. Same `gh` flags and same idea, narrower
+  marker convention.
+- `partio-minions/internal/program/parse_test.go` — re-validates the
+  program file after the prompt edits.
+
+## Out of scope
+
+- Diff/version tracking for the PRD comment. PRD: *Out of Scope* —
+  first version overwrites or regenerates; no history is kept.
+- An integration test that runs `research.md` twice and asserts no
+  duplicates programmatically. PRD's *Testing Decisions* note:
+  "Build only if a real re-run produces duplicates." For now, smoke
+  is sufficient.
+- Cleaning up child issues created in earlier (now-superseded)
+  research runs. The publisher reconciles, it does not garbage
+  collect.

--- a/docs/2026-05-05-research-minion/issues/06-production-smoke-run.md
+++ b/docs/2026-05-05-research-minion/issues/06-production-smoke-run.md
@@ -1,0 +1,97 @@
+# 06 — First production smoke run
+
+**Source PRD**: [../prd.md](../prd.md)
+**Blocked by**: [05 — Idempotency: re-runs skip existing artifacts](./05-idempotency-rerun-skip.md)
+
+## What to build
+
+This slice is operational, not code. Pick a small, well-scoped parent
+issue on `partio-io/cli` and put the full `research.md` chain through
+its first production run. The goal is to validate, before trusting
+the auto-cascade for the long tail of complex tasks, that:
+
+- The chain completes within the 90-minute timeout against a real,
+  non-trivial parent issue.
+- The PRD comment is substantive — a stranger reading just the parent
+  issue thread can understand what's being built and why.
+- The child issues are the right granularity (vertical, demoable,
+  thin) and reference the parent.
+- No personal data leaks from the persona substrate into any public
+  artifact (PRD comment, child issue bodies, status comment, run
+  logs).
+- The parent issue stays open and is correctly labeled
+  `minion-research-completed`.
+
+The procedure intentionally pauses the auto-cascade for this first
+run. After the publisher opens child issues with `minion-approved` +
+`minion-research-output`, you remove the `minion-approved` label
+manually from each child *before* `minion.yml` fires `implement.md`.
+That gives a human review gate on the research output the very first
+time, and only the very first time. Once the smoke is clean, future
+runs trust the cascade end-to-end (the PRD's *Testing Decisions*
+section is explicit: "After the first successful smoke run, future
+runs trust the cascade.").
+
+## Acceptance criteria
+
+- [ ] Parent issue selected: a real `minion-proposal` issue from the
+  cli queue, or a synthetic complex-task issue authored for the
+  smoke. Recorded in the PR/notes attached to closing this slice.
+- [ ] `minion-research` label applied to the chosen parent. Workflow
+  log shows the run firing within seconds, passing the
+  `author_association` gate, and cloning argos master successfully.
+- [ ] Run completes inside the 90-minute timeout. Total wall-clock
+  time recorded in the smoke notes.
+- [ ] PRD comment present on the parent, substantive, and matches
+  the shape produced by `/code-create-prd` (Problem Statement,
+  Solution, User Stories, Implementation Decisions, Testing
+  Decisions, Out of Scope, Further Notes — or the agreed
+  near-equivalent).
+- [ ] Child issues opened, each with `minion-approved` and
+  `minion-research-output` labels and the
+  `<!-- minion:slice parent=#<N> slice=<n>/<total> -->` marker.
+- [ ] Status comment present on the parent listing all child issue
+  numbers with the `minion:research-status` marker.
+- [ ] Parent labeled `minion-research-completed`. Parent issue state
+  is `open`. No `minion-done` label on the parent.
+- [ ] Privacy review of every public artifact (PRD comment, every
+  child body, status comment): no Whoop/Garmin numbers, no diary
+  excerpts, no calendar event names, no financial figures, no
+  specific location strings, no quotes or paraphrases of TELOS or
+  memory content.
+- [ ] `minion-approved` removed from each child issue manually
+  before `minion.yml` fires on it (this is the deliberate
+  first-run gate). Smoke notes record which children would have
+  fired.
+- [ ] Smoke notes capture any persona blind spots, awkward question
+  trees, or PRD-shape issues observed. These notes seed the future
+  "tune-up gotchas" file (still out of scope here per PRD) and
+  inform whether TELOS or memory updates are warranted (handled via
+  the normal argos PR flow, not in this PR).
+
+## Modules touched
+
+- None — this slice runs the system end-to-end against existing
+  artifacts and reports.
+
+## Test prior art
+
+- The PRD's *Testing Decisions / Modules to verify / End-to-end
+  smoke* bullet describes this exact procedure.
+- `partio-cli/.github/workflows/minion.yml` — example of the same
+  runner / OAuth subscription auth path being exercised in
+  production.
+
+## Out of scope
+
+- Building a CI assertion or scheduled test that scans research-run
+  outputs for personal-data substrings. PRD: *Testing Decisions* —
+  "Build only if a leak is observed in a real run."
+- A persona "tune-up gotchas" file. PRD: *Out of Scope* — defer
+  until persona misbehavior is observed.
+- Automating the manual `minion-approved` strip. The strip is
+  deliberately a one-time, first-smoke procedure; production runs
+  should let the cascade fire.
+- Any changes to `propose.yml`, `approve.yml` cron, or
+  `author_association` on the existing `minion.yml`. PRD:
+  *Out of Scope*.

--- a/docs/2026-05-05-research-minion/prd.md
+++ b/docs/2026-05-05-research-minion/prd.md
@@ -1,0 +1,182 @@
+# research-minion
+
+## Problem Statement
+
+The current minion system handles small, well-specified tasks well: a human files an issue on `partio-io/cli`, labels it `minion-approved` (or comments `/minion build`), and `implement.md` runs unattended to produce a PR. That fast path is sufficient when the spec is tight and the change is small.
+
+It is not sufficient for complex work. Many of the proposals sitting in the cli queue (270+ open `minion-proposal` issues, plus ad-hoc complex tasks jcleira wants to tackle) require research and decomposition before implementation. Today, jcleira handles that complexity interactively through the `/code-research` → `/code-create-prd` → `/code-create-issues` → `/code-execute-issue` skill chain — each step requires him at the keyboard, answering questions and making decisions.
+
+That contradicts the stated goal: "many one-shot tasks per day." If every complex task pulls jcleira into a 30-minute interactive interview, the system caps at the rate jcleira can sit and interview — far below the rate at which complex tasks accumulate.
+
+The system needs a path that fires complex tasks the same way it fires simple ones: tag the issue, walk away, get PRs back. That path must produce decisions of the same quality jcleira would produce live, while consuming none of his interactive time.
+
+## Solution
+
+A new minion path for complex tasks runs the full research → PRD → slice → implement pipeline unattended.
+
+A new GitHub label `minion-research` (or comment `/minion research`) on a parent issue triggers a new workflow `research.yml` on partio-io/cli. That workflow fires `research.md`, a multi-agent program with five sub-agents:
+
+1. **researcher** — drives an interview in the style of `/code-research`, walking the decision tree and writing Q&A to a transcript file in the worktree.
+2. **persona** — answers each question as jcleira would, grounded in argos's full `telos/*.md` (~5K chars) and `memory/*.md` (~120K chars across 48 files). Cloned fresh from `git@github.com:jcleira/argos.git` (master branch) into the workspace at workflow start. Strict directive in the prompt: use the substrate to *decide*, never quote or paraphrase personal content in any output.
+3. **prd-writer** — synthesizes the transcript into a PRD body.
+4. **slicer** — breaks the PRD into vertical-slice descriptions, one per child issue.
+5. **publisher** — uses the `gh` CLI to: post the PRD as a comment on the parent issue, open one child issue per slice, label parent with `minion-research-completed`, and post a status comment with child issue links.
+
+Child issues are created with two labels: `minion-approved` (so the existing `minion.yml` workflow auto-fires `implement.md` for each) and `minion-research-output` (provenance, for filtering). The auto-fire cascade is intentional: jcleira approves the original parent issue once, and the system runs research → decomposition → implementation without further intervention. The only manual gate is final PR review — same as today's simple-task flow.
+
+All artifacts stay on GitHub Issues and Pull Requests; no `docs/.../prd.md` or `docs/.../issues/*.md` files get committed. Idempotency markers (`<!-- minion:research run-id=<sha> -->` on the PRD comment, `<!-- minion:slice parent=#N -->` on child issue bodies) let re-runs detect existing artifacts and avoid duplication.
+
+The existing simple-task flow is preserved unchanged. The propose pipeline (twice-daily cron generating `minion-proposal` issues from competitor monitoring) keeps running. New labels and the new workflow live alongside existing ones.
+
+## User Stories
+
+1. As jcleira, I want to mark a complex partio-io/cli issue with `minion-research`, so that the system runs research, decomposition, and implementation without further intervention from me.
+2. As jcleira, I want a "persona" sub-agent that decides as I would, so that the unattended research phase produces the same answers I'd give if I were at the keyboard.
+3. As jcleira, I want the persona grounded in my full `telos/*.md` and all 48 `memory/*.md` files, so that decisions reflect my current goals, projects, beliefs, and learned preferences without me writing a separate persona file.
+4. As jcleira, I want the persona to use TELOS/memory only for decision-making and never to quote, paraphrase, or reference personal data in any output, so that public PRs and issue comments don't leak my health, training, financial, or location information.
+5. As jcleira, I want each minion phase (research, PRD synthesis, slice creation, slice implementation) to run as its own one-shot Claude session within the multi-agent program, so that each phase has clean context and the system stays composable.
+6. As jcleira, I want the research minion to post the PRD as a comment on the parent issue rather than commit it as a doc file, so that the entire chain stays on GitHub Issues and PRs without producing extra `docs/` artifacts.
+7. As jcleira, I want the research minion to open child issues directly via `gh` (not commit issue files), so that humans and the existing `minion.yml` workflow see the same artifacts in the same place.
+8. As jcleira, I want each child issue to carry both `minion-approved` (to auto-fire implement.md) and `minion-research-output` (for provenance filtering), so that the auto-cascade works and so that I can identify which issues came from research runs at a glance.
+9. As jcleira, I want the parent research issue to receive a `minion-research-completed` label and a status comment listing child issue links, so that the relationship between parent proposal and child slices is human-readable in the issue thread.
+10. As jcleira, I want the parent research issue to stay open (not auto-close, no `minion-done` label) until I decide it's resolved, so that the issue serves as a hub for the work it spawned.
+11. As jcleira, I want the existing simple-task flow (`minion-approved` label fires `implement.md` directly) to remain untouched, so that I can keep using the fast path for tasks I judge to be small.
+12. As jcleira, I want to be able to triage a `minion-proposal` issue into either `minion-approved` (simple, direct implement) or `minion-research` (complex, full pipeline) based on my judgment, so that I have a fast path and a thorough path on the same proposal queue.
+13. As jcleira, I want to run the research minion locally first (via `minions run .minions/programs/research.md --dry-run` with a workspace cloned side-by-side) before trusting CI, so that I can debug a new program without fighting CI feedback delay.
+14. As jcleira, I want the research workflow to clone `jcleira/argos` at runtime via the PAT, so that the persona always reads the latest TELOS and memory state and so that any future runner (laptop replacement, VM, hosted runner) works without additional setup.
+15. As jcleira, I want the workflow to clone argos's `master` branch (since argos uses `master`, not `main`), so that the clone step doesn't fail silently on a partio-io-conventional `main` assumption.
+16. As jcleira, I want the research workflow to enforce `author_association in [OWNER, MEMBER, COLLABORATOR]` before firing, so that random commenters on the public cli repo cannot trigger research runs that consume my OAuth subscription quota.
+17. As jcleira, I want a 90-minute workflow timeout (vs the existing 30 minutes on `minion.yml`), so that long research + PRD + slicing runs do not get killed mid-flight.
+18. As jcleira, I want minion-authored issue comments prefixed with `<!-- minion:research run-id=<sha7> -->` and child issue bodies prefixed with `<!-- minion:slice parent=#N -->`, so that re-runs of `research.md` against the same parent issue can detect existing artifacts and avoid duplicating work.
+19. As jcleira, I want the slicer agent to check for an existing PRD comment (by marker) before writing a new one, so that re-running `research.md` doesn't post a second PRD or open duplicate child issues.
+20. As jcleira, I want the persona substrate to load all of `telos/*.md` and all of `memory/*.md` without filtering, so that the persona has full grounding without me curating which files are "important enough."
+21. As jcleira, I want the research minion to share the same self-hosted runner, OAuth subscription auth, and PAT setup as the existing propose/implement minions, so that I don't introduce a new auth surface or new infrastructure to maintain.
+22. As jcleira, I want `secrets.GH_PAT` on partio-io/cli scoped so it can read `jcleira/argos`, so that the workflow's clone step succeeds.
+23. As jcleira, I want the research workflow to NOT auto-close the parent issue or add `minion-done` (unlike `minion.yml`'s success path), so that the parent stays open until I close it manually.
+24. As jcleira, I want to retain the option to add a "tune-up gotchas" file later (without rebuilding the system), so that I can correct the persona's blind spots when I see them in real runs.
+25. As jcleira, I want the propose loop to keep running unchanged (twice-daily cron generating `minion-proposal` issues), so that competitor-monitoring continues while I rebuild engagement with the system.
+26. As jcleira, I want minion-failed signals (existing `minion-failed` label + comment with run URL) reused for research failures, so that I have a consistent observability story across all minion paths.
+27. As jcleira, I want PR review to remain the only manual gate downstream of `minion-research` approval, so that I can fire complex tasks and walk away exactly the way I fire simple ones.
+28. As future jcleira (or successor), I want this design captured as a PRD so that decisions about persona substrate, idempotency, and chain semantics aren't reconstructed from scratch when adjustments become necessary.
+29. As jcleira, I want no code change to the `partio-minions` Go binary, so that the runtime stays simple and this feature is purely additive at the program / workflow / config layer.
+30. As jcleira, I want the privacy directive to be hard-coded in `research.md`'s persona-agent prompt (not a separate convention I have to remember), so that the protection is load-bearing and tested every run rather than relying on author discipline.
+
+## Implementation Decisions
+
+### Modules built or modified
+
+- **`research.md` program** (new, in `partio-io/cli/.minions/programs/`). Multi-agent program with five sub-agents executed sequentially in a single minion run: researcher, persona, prd-writer, slicer, publisher. Each agent has its own prompt; they share a worktree and pass state via files (transcript, draft PRD, slice list). Frontmatter declares `target_repos: [cli]`, no acceptance criteria (no code is written by the research run itself), and no `pr_labels` (no PR is created).
+- **`research.yml` workflow** (new, in `partio-io/cli/.github/workflows/`). Mirrors `minion.yml`'s structure with these differences: triggers on `issues.labeled` for `minion-research` and on `issue_comment` containing `/minion research`; gates on `author_association` in `[OWNER, MEMBER, COLLABORATOR]`; clones `jcleira/argos` (master) into the workspace before invoking minions; 90-minute timeout; omits the success-path "Mark done" / auto-close steps.
+- **GitHub labels on `partio-io/cli`** (new): `minion-research` (input trigger), `minion-research-output` (provenance on slicer-created child issues), `minion-research-completed` (parent state after research run succeeds).
+- **`secrets.GH_PAT`** scope expansion to grant read access to `jcleira/argos`. Configuration change, no file change.
+- **No changes to `partio-minions`**. The Go binary already supports multi-agent programs, sequential execution, context hints, and gh-CLI side effects from agent prompts. `research.md` is a new consumer of that runtime, not an extension of it.
+- **No changes to `implement.md`, `minion.yml`, `propose.md`, `propose.yml`, `approve.md`, `doc-update.md`, `readme-update.md`, `ingest.md`**. Existing simple-task flow and propose pipeline run untouched.
+
+### Module interfaces (program-level, not file-level)
+
+- **researcher → persona handoff**: researcher writes one question at a time to a transcript file (`./research-transcript.md`); persona reads the latest unanswered question, appends an answer block. Both agents loop over the same file until researcher emits a `RESEARCH_COMPLETE` marker.
+- **prd-writer reads** the completed transcript, writes a draft PRD to `./prd-draft.md`.
+- **slicer reads** `./prd-draft.md`, writes a slice list to `./slices.md` (one block per slice with title, description, acceptance criteria).
+- **publisher reads** `./prd-draft.md` and `./slices.md`, executes `gh` calls to post the PRD comment, open child issues, and label the parent. All `gh`-emitted artifacts include idempotency markers.
+
+### Persona privacy directive
+
+The persona-agent's prompt contains a literal, hard-coded directive: "Use TELOS and memory to *decide* — what answer would jcleira give? Never quote, paraphrase, or reference personal data (health, training, daily diary content, finances, location, calendar) in any output. Output answers in your own words, framed as decisions on the question at hand." This line is load-bearing and must not be edited away.
+
+### Persona substrate scope
+
+`research.md` declares `## Context` hints for `argos/telos/MISSION.md`, `argos/telos/GOALS.md`, `argos/telos/PROJECTS.md`, `argos/telos/BELIEFS.md`, all of `argos/memory/*.md` (48 files, ~120K chars). No filtering; the persona-agent decides at runtime which substrate is relevant per question. Total token cost ~31K, fully cacheable across runs.
+
+### Idempotency contract
+
+Three markers, each a single HTML comment line:
+
+- PRD comment: first line is `<!-- minion:research run-id=<sha7-of-issue-events-or-similar> -->`.
+- Child issue body: first line is `<!-- minion:slice parent=#<N> slice=<n>/<total> -->`.
+- Slicer's parent-issue status comment: first line is `<!-- minion:research-status parent=#<N> -->`.
+
+The publisher agent's prompt instructs it to query the parent issue's existing comments via `gh issue view --json comments` and skip writing comments whose marker matches an existing one (regenerating instead).
+
+### Auto-cascade trigger semantics
+
+- `minion-research` label OR `/minion research` comment on parent issue → fires `research.yml`.
+- `research.md`'s slicer agent creates child issues with `minion-approved` + `minion-research-output` labels. The `minion-approved` label is the existing trigger for `minion.yml`, so each child issue auto-fires `implement.md`.
+- No new wiring is needed between research and implement — they compose via the existing label.
+
+### Architectural decisions
+
+- **Clone argos fresh per workflow run** (vs symlinking the runner-resident clone, vs snapshotting from runner filesystem). Reproducibility (workflow log shows exact argos SHA used) and portability (no runner-host coupling) outweigh the ~5s clone overhead. Alternative paths were considered and rejected; revisit if the laptop runner is replaced or augmented.
+- **Each minion phase runs as its own Claude session within a single program run** (sub-agents in `## Agents`), not as separate program files chained through GH. Within-run sub-agents are simpler to coordinate, share a worktree natively, and produce one workflow run per parent issue (cleaner observability) instead of N runs across the chain.
+- **All artifacts on GitHub** (issues, comments, PRs); no `docs/` files committed. Keeps the chain on a single surface; `gh` is already available in the agent's Bash tool; no new sync mechanism between docs/ and the issue tracker.
+- **Three labels not one.** `minion-research`, `minion-research-output`, `minion-research-completed` separate input trigger, child provenance, and parent state. Each is queryable independently.
+- **No PR created by the research run**. The research minion produces only GitHub side effects (comments, issue creates, label adds). The existing executor handles "no worktree changes" by marking the run skipped (not failed); the run still succeeds and side effects persist.
+
+### Schema changes
+
+Three new repo labels on `partio-io/cli`. No data schema, no API contracts, no migrations.
+
+### API contracts
+
+No new APIs. All inter-component communication is one of: (a) GitHub label/issue/comment state, (b) files in the worktree shared between sub-agents, (c) idempotency markers in comment/issue body content.
+
+### Specific interactions
+
+- Human applies `minion-research` to parent issue → `research.yml` fires.
+- Workflow clones argos into `${{ github.workspace }}/argos/`.
+- Workflow runs `minions run .minions/programs/research.md --issue <N>`.
+- Sub-agents run sequentially: researcher → persona → prd-writer → slicer → publisher.
+- Publisher posts PRD comment, opens child issues, labels parent.
+- Workflow ends without closing parent.
+- Each child issue's `minion-approved` label causes `minion.yml` to fire on it.
+- `implement.md` runs per child, opens PR.
+- Human reviews + merges each PR.
+- Human manually closes parent issue when satisfied.
+
+## Testing Decisions
+
+- **What makes a good test for this system**: end-to-end runs against real test issues. The system's behavior is dominated by Claude prompts, GitHub side effects, and workflow YAML semantics. Unit tests on agent prompts have low signal because the prompts are natural-language; small text changes don't break parseability and large semantic changes are not caught by any cheap assertion.
+- **External behavior (what to test)**: the contract is "given a complex parent issue with `minion-research` label, the system produces a PRD comment + N child issues + parent labeled `minion-research-completed`, and child PRs eventually appear via the existing implement chain." Anything internal to the program (agent ordering, transcript file format, prompt phrasing) is implementation detail.
+- **Implementation details (what NOT to test)**: transcript file format, sub-agent prompt phrasing, the specific token counts of substrate, the exact wording of the persona privacy directive (its presence is what matters; its phrasing is tuned over time).
+
+### Modules to verify
+
+- **`research.md` parses cleanly**: covered by partio-minions's existing `internal/program/parse_test.go` infrastructure; running `minions run research.md --dry-run` is sufficient to validate the program file. No new test code required.
+- **`research.yml` parses cleanly**: GitHub validates workflow YAML on push; failures surface immediately. No new test code required.
+- **End-to-end smoke**: a controlled first run on a small/known parent issue, with the slicer's `minion-approved` label removed manually before children fire, so the research output is reviewed before any implement runs. After the first successful smoke run, future runs trust the cascade.
+
+### Modules to consider for future tests (post-v1)
+
+- **Idempotency**: integration test that runs `research.md` twice on the same parent issue and verifies no duplicate PRD comment, no duplicate child issues. Build only if a real re-run produces duplicates.
+- **Persona privacy**: a regression assertion scanning research run logs (or output artifacts) for known-personal-data substrings (e.g., specific Whoop / TrainingPeaks / financial terms). Build only if a leak is observed in a real run.
+
+### Prior art
+
+- `partio-minions/internal/program/parse_test.go` validates program parsing. Continues to apply.
+- No existing test for workflow behavior or for cross-program label-chained execution. This feature does not introduce new tests there; smoke runs are the verification.
+
+## Out of Scope
+
+- **Persona "tune-up gotchas" file**. Defer until persona misbehavior is observed in real runs; predicting gotchas without data wastes effort.
+- **Pre-flight check that argos clone is on master and clean**. The clone-fresh strategy sidesteps mid-state risk.
+- **Automated parent-close when all child PRs are merged**. Manual close is fine for v1.
+- **Escalation logic in `implement.md`** ("this task is too big, escalate to research"). Trust human triage to choose path.
+- **Cost / quota dashboards**. Subscription quota is the real ceiling; existing run logs report token counts. Build observability only if quota becomes a constraint.
+- **Multi-runner / hosted-runner support beyond the existing self-hosted laptop runner**. Workflow clones argos via PAT to keep the future open, but no hosted runner is being provisioned now.
+- **PRD-comment versioning / history**. First version overwrites or regenerates; no diff tracking.
+- **Persona "learning" from past runs**. Persona is stateless per run. Tuning happens via the gotchas file (out of scope) or via TELOS/memory updates (continuous, separate process).
+- **Changes to existing simple-task flow**. `minion.yml`, `implement.md`, `propose.md`, `propose.yml`, `approve.md`, `doc-update.md`, `ingest.md`, `readme-update.md` all unchanged.
+- **Replacement or refocus of propose pipeline**. Decision was to keep it running unchanged.
+- **README rewrites for partio-minions or cli**. Acknowledged as stale; not in this PRD.
+- **`approve.yml` cron** (auto-approve proposals after 24h). Mentioned as a missing piece elsewhere; not part of this PRD.
+- **Author_association tightening on existing `minion.yml`**. Worth doing eventually; only `research.yml` requires it for this feature.
+- **Minion-failure recovery beyond the existing `minion-failed` label + log link comment**. Same observability as today.
+
+## Further Notes
+
+- The self-hosted runner `github-runner-partio-minion-ai-01` is on jcleira's laptop (`/home/arvos/...`). OAuth subscription auth flows through `~/.claude/.credentials.json` on that machine. Any infra change affecting the laptop affects the runner.
+- Subscription quota is the real cost ceiling. API-equivalent valuations in run logs (~$0.83/propose-run) are not billed dollars under OAuth; usage counts against Claude Max rolling/weekly caps. Many one-shots per day may bump those caps.
+- `argos`'s default branch is `master`, not `main`. Workflow clone step must respect that.
+- This design is the spiritual sibling of the `/code-research` → `/code-create-prd` → `/code-create-issues` → `/code-execute-issue` skill chain, executed headlessly with a persona-agent in jcleira's seat and GitHub artifacts replacing local doc files.
+- partio-minions's reboot history (partio-minions-claude-code → minion-multirepository → minion-programs → minion-programs-only → current) deliberately stripped functionality. This PRD is purely additive at the program/workflow/config layer; it does not reverse the simplification trajectory of the binary.
+- The current propose pipeline produces 1–5 `minion-proposal` issues/day from competitor monitoring of `entireio`. Some of those may be the natural first inputs for the research minion: triage proposal → judge complexity → label `minion-approved` (simple) or `minion-research` (complex).
+- This PRD lives in `partio-minions/docs/` because the research-minion design is fundamentally about the minion runtime's usage pattern. The implementation artifacts (`research.md`, `research.yml`, labels, PAT scope) all land in `partio-io/cli` when built.


### PR DESCRIPTION
## Summary

- Adds the PRD for a new `research-minion` path that runs the full research → PRD → slice → implement pipeline unattended on `partio-io/cli`.
- Breaks the PRD into six tracer-bullet vertical slices (workflow skeleton → researcher+persona → prd-writer → slicer → idempotency → production smoke run), each self-contained enough that a fresh Claude session can pick it up against just the issue file plus the repo.
- No code change to the partio-minions Go runtime — implementation artifacts (`research.md`, `research.yml`, three new labels, PAT scope) will all land in `partio-io/cli` when each slice is built.

## Test plan

- [ ] Read `docs/2026-05-05-research-minion/prd.md` end to end and confirm it captures the design intent (persona substrate, privacy directive, idempotency contract, auto-cascade semantics).
- [ ] Walk `docs/2026-05-05-research-minion/issues.md` and confirm the dependency order makes sense (#1 → #2 → #3 → #4 → #5 → #6).
- [ ] Spot-check one of the per-issue files (e.g., `issues/01-workflow-skeleton.md`) and confirm a fresh Claude session given just that file plus `partio-cli/` could start work without re-reading the PRD.
- [ ] Confirm slice granularity feels right (each demoable on its own; not so thin as to be noise; not so thick that implementation outgrows one session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)