### PR TITLE
fix: unique implement branch per issue (stop shared-PR collisions)

### DIFF
--- a/cmd/minions/run.go
+++ b/cmd/minions/run.go
@@ -50,16 +50,16 @@ Examples:
 			}
 
 			// Fetch issue context if --issue is provided
-			var issueContext string
+			var issueContext, issueNumber string
 			if issueRef != "" {
 				var err error
-				issueContext, err = fetchIssue(issueRef)
+				issueContext, issueNumber, err = fetchIssue(issueRef)
 				if err != nil {
 					return fmt.Errorf("fetching issue: %w", err)
 				}
 			}
 
-			return runProgram(ctx, args[0], workspaceRoot, issueContext, dryRun)
+			return runProgram(ctx, args[0], workspaceRoot, issueContext, issueNumber, dryRun)
 		},
 	}
 
@@ -69,9 +69,11 @@ Examples:
 	return cmd
 }
 
-// fetchIssue fetches an issue's title and body via gh CLI.
-// Accepts either a bare number (uses principal repo) or a full reference (org/repo#123).
-func fetchIssue(ref string) (string, error) {
+// fetchIssue fetches an issue's title and body via gh CLI and returns the
+// parsed issue number alongside the body. Accepts either a bare number (uses
+// principal repo) or a full reference (org/repo#123). The number is returned
+// so the caller can make the per-build taskID/branch unique.
+func fetchIssue(ref string) (string, string, error) {
 	var repo, number string
 
 	if strings.Contains(ref, "#") {
@@ -81,7 +83,7 @@ func fetchIssue(ref string) (string, error) {
 	} else {
 		// Bare number — use principal repo from project config
 		if proj == nil {
-			return "", fmt.Errorf("--issue with bare number requires project config (pass org/repo#number or ensure .minions/project.yaml exists)")
+			return "", "", fmt.Errorf("--issue with bare number requires project config (pass org/repo#number or ensure .minions/project.yaml exists)")
 		}
 		repo = proj.PrincipalFullName()
 		number = ref
@@ -90,9 +92,9 @@ func fetchIssue(ref string) (string, error) {
 	cmd := exec.Command("gh", "issue", "view", number, "--repo", repo, "--json", "title,body", "--jq", `"# " + .title + "\n\n" + .body`)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh issue view %s --repo %s: %w", number, repo, err)
+		return "", "", fmt.Errorf("gh issue view %s --repo %s: %w", number, repo, err)
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(string(out)), number, nil
 }
 
 func debugDirForTask(taskID string) string {
@@ -105,7 +107,7 @@ func debugDirForTask(taskID string) string {
 	return dir
 }
 
-func runProgram(ctx context.Context, programPath, workspaceRoot, issueContext string, dryRun bool) error {
+func runProgram(ctx context.Context, programPath, workspaceRoot, issueContext, issueRef string, dryRun bool) error {
 	prog, err := program.LoadFile(programPath)
 	if err != nil {
 		return err
@@ -170,6 +172,7 @@ func runProgram(ctx context.Context, programPath, workspaceRoot, issueContext st
 		Program:       prog,
 		PlanText:      planText,
 		IssueContext:  issueContext,
+		IssueRef:      issueRef,
 		WorkspaceRoot: workspaceRoot,
 		Project:       proj,
 		Tracker:       tracker,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -26,6 +26,7 @@ type Opts struct {
 	Program       *program.Program
 	PlanText      string
 	IssueContext  string // fetched issue body, injected into prompt
+	IssueRef      string // issue number (e.g. "437"); appended to taskID so each build gets its own branch/PR
 	WorkspaceRoot string
 	Project       *project.Project
 	Tracker       *pcontext.Tracker
@@ -88,10 +89,22 @@ func Run(ctx gocontext.Context, opts Opts) (*Result, error) {
 	return result, nil
 }
 
+// buildTaskID derives the per-run task identifier used for the worktree path
+// and the PR branch name (minion/<taskID>). When an issue reference is present
+// it is appended, so each issue-triggered build gets its own branch and PR
+// instead of colliding on a single shared branch shared across every run.
+func buildTaskID(progID, agentName, issueRef string) string {
+	id := progID + "-" + agentName
+	if issueRef != "" {
+		id += "-" + issueRef
+	}
+	return id
+}
+
 // runAgent executes a single sub-agent.
 func runAgent(ctx gocontext.Context, opts Opts, prog *program.Program, agent *program.AgentDef) AgentResult {
 	repos := prog.EffectiveTargetRepos(agent)
-	taskID := prog.ID + "-" + agent.Name
+	taskID := buildTaskID(prog.ID, agent.Name, opts.IssueRef)
 	multiRepo := len(repos) > 1
 
 	// Start context tracking

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,69 @@
+package executor
+
+import "testing"
+
+func TestBuildTaskID(t *testing.T) {
+	tests := []struct {
+		name      string
+		progID    string
+		agentName string
+		issueRef  string
+		want      string
+	}{
+		{
+			name:      "no issue keeps prog-agent shape",
+			progID:    "implement",
+			agentName: "implement",
+			issueRef:  "",
+			want:      "implement-implement",
+		},
+		{
+			name:      "issue number is appended for uniqueness",
+			progID:    "implement",
+			agentName: "implement",
+			issueRef:  "437",
+			want:      "implement-implement-437",
+		},
+		{
+			name:      "different issue yields a different task id",
+			progID:    "implement",
+			agentName: "implement",
+			issueRef:  "511",
+			want:      "implement-implement-511",
+		},
+		{
+			name:      "named agent with issue",
+			progID:    "research",
+			agentName: "publisher",
+			issueRef:  "120",
+			want:      "research-publisher-120",
+		},
+		{
+			name:      "named agent without issue",
+			progID:    "research",
+			agentName: "publisher",
+			issueRef:  "",
+			want:      "research-publisher",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildTaskID(tt.progID, tt.agentName, tt.issueRef); got != tt.want {
+				t.Errorf("buildTaskID(%q, %q, %q) = %q, want %q",
+					tt.progID, tt.agentName, tt.issueRef, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildTaskID_DistinctPerIssue is the regression guard for the shared-branch
+// bug: two builds of the same program+agent for different issues must not share
+// a task id (and therefore must not share a branch / PR).
+func TestBuildTaskID_DistinctPerIssue(t *testing.T) {
+	a := buildTaskID("implement", "implement", "437")
+	b := buildTaskID("implement", "implement", "438")
+	if a == b {
+		t.Fatalf("expected distinct task ids per issue, both were %q", a)
+	}
+}


### PR DESCRIPTION
## Objective

Each issue-triggered build now gets its own branch + PR, instead of every `implement` run reusing the single branch `minion/implement-implement`.

## Why

`taskID` was `prog.ID + "-" + agent.Name` — a constant `implement-implement` for the implement program. So every build reused `minion/implement-implement`, and a new build pushed into whatever PR was already open on that branch. In practice this mashed unrelated features into one PR (we hit `partio list` + `partio prune` + an unrelated `research.md` change colliding in a single PR, and the issue got auto-closed `minion-done` anyway). The one-PR-per-feature flow was broken.

## How

- Thread the parsed issue number from `fetchIssue` → `runProgram` → `executor.Opts.IssueRef`.
- Extract `buildTaskID(progID, agentName, issueRef)`; append `-<issueRef>` when an issue is present → e.g. `implement` on issue 437 produces branch `minion/implement-implement-437`. Programs run without an issue keep their existing taskID.
- Table-driven tests for `buildTaskID`, plus a regression guard that two different issues never share a taskID.

`go build`, `go vet`, and `go test ./...` all pass.

> ⚠️ Heads-up: the CI workflows in `partio-io/cli` install minions pinned at `@v0.0.5`. This fix only takes effect in CI after a new minions release **and** bumping that pin in the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
