### PR TITLE
docs: reconcile research-minion plan with the shipped comment design

### DIFF
--- a/docs/2026-05-05-research-minion/issues.md
+++ b/docs/2026-05-05-research-minion/issues.md
@@ -4,9 +4,10 @@ Source: [prd.md](./prd.md)
 
 | Done | # | Title | Blocked by |
 |------|---|-------|------------|
-| [ ]  | 1 | [Workflow skeleton — label fires workflow, posts a stub comment](./issues/01-workflow-skeleton.md) | None |
-| [ ]  | 2 | [Researcher + persona produce a Q&A transcript](./issues/02-researcher-persona-transcript.md) | [#1](./issues/01-workflow-skeleton.md) |
-| [ ]  | 3 | [prd-writer agent + PRD comment + parent label](./issues/03-prd-writer-comment-label.md) | [#2](./issues/02-researcher-persona-transcript.md) |
-| [ ]  | 4 | [slicer agent + child issues + status comment](./issues/04-slicer-child-issues.md) | [#3](./issues/03-prd-writer-comment-label.md) |
-| [ ]  | 5 | [Idempotency — re-runs skip existing artifacts](./issues/05-idempotency-rerun-skip.md) | [#4](./issues/04-slicer-child-issues.md) |
-| [ ]  | 6 | [First production smoke run](./issues/06-production-smoke-run.md) | [#5](./issues/05-idempotency-rerun-skip.md) |
+| [x]  | 1 | [Workflow skeleton — label fires workflow, posts a stub comment](./issues/01-workflow-skeleton.md) | None |
+| [x]  | 2 | [Researcher + persona produce a Q&A transcript](./issues/02-researcher-persona-transcript.md) | [#1](./issues/01-workflow-skeleton.md) |
+| [x]  | 3 | [prd-writer agent + PRD comment + parent label](./issues/03-prd-writer-comment-label.md) | [#2](./issues/02-researcher-persona-transcript.md) |
+| [x]  | 4 | [slicer agent + child issues + status comment](./issues/04-slicer-child-issues.md) — **superseded by #7** | [#3](./issues/03-prd-writer-comment-label.md) |
+| [x]  | 7 | [Slice plan as a comment + manual one-PR build (replaces #4)](./issues/07-slice-plan-comment-manual-build.md) | [#3](./issues/03-prd-writer-comment-label.md) |
+| [ ]  | 5 | [Idempotency — re-runs skip existing artifacts](./issues/05-idempotency-rerun-skip.md) — *premise revised by #7* | [#7](./issues/07-slice-plan-comment-manual-build.md) |
+| [ ]  | 6 | [First production smoke run](./issues/06-production-smoke-run.md) — *procedure revised by #7* | [#5](./issues/05-idempotency-rerun-skip.md) |

--- a/docs/2026-05-05-research-minion/issues/04-slicer-child-issues.md
+++ b/docs/2026-05-05-research-minion/issues/04-slicer-child-issues.md
@@ -3,6 +3,14 @@
 **Source PRD**: [../prd.md](../prd.md)
 **Blocked by**: [03 — prd-writer agent + PRD comment + parent label](./03-prd-writer-comment-label.md)
 
+> **Superseded by slice [#07](./07-slice-plan-comment-manual-build.md).**
+> This slice was built and merged (partio-io/cli#404), then **replaced**:
+> the child-issue + auto-cascade approach below proliferated issues and
+> collided feature PRs on a shared branch. The shipped design posts the
+> slice plan as a *comment* on the parent and triggers implementation
+> manually as a single PR. Kept as history; the acceptance criteria below
+> describe behavior that has since been removed.
+
 ## What to build
 
 Add a `slicer` sub-agent that runs between `prd-writer` and

--- a/docs/2026-05-05-research-minion/issues/05-idempotency-rerun-skip.md
+++ b/docs/2026-05-05-research-minion/issues/05-idempotency-rerun-skip.md
@@ -3,6 +3,15 @@
 **Source PRD**: [../prd.md](../prd.md)
 **Blocked by**: [04 — slicer agent + child issues + status comment](./04-slicer-child-issues.md)
 
+> **Premise revised — see slice [#07](./07-slice-plan-comment-manual-build.md).**
+> Written when a run produced three artifact types (PRD comment, child
+> issues, status comment). Under the shipped design a run produces only
+> **two comments** on the parent — the PRD comment (`minion:research
+> run-id=`) and the slice-plan comment (`minion:research-slices
+> parent=#N`) — and no child issues. The skip-if-marker-exists work still
+> applies, but only to those two comments; the child-issue and
+> status-comment markers below are obsolete. Not yet built.
+
 ## What to build
 
 Make `research.md` safe to re-run against the same parent issue

--- a/docs/2026-05-05-research-minion/issues/06-production-smoke-run.md
+++ b/docs/2026-05-05-research-minion/issues/06-production-smoke-run.md
@@ -3,6 +3,15 @@
 **Source PRD**: [../prd.md](../prd.md)
 **Blocked by**: [05 — Idempotency: re-runs skip existing artifacts](./05-idempotency-rerun-skip.md)
 
+> **Procedure revised — see slice [#07](./07-slice-plan-comment-manual-build.md).**
+> The shipped design has no auto-cascade to pause, so the "remove
+> `minion-approved` from each child before it fires" step below is
+> obsolete. The current smoke is: label the parent `minion-research` →
+> verify the PRD + slice-plan comments → then label the parent
+> `minion-approved` to produce one feature PR. A dry run of exactly this
+> was done end-to-end on partio-io/cli#437 (→ PR #443). Not yet run
+> against a real `minion-proposal` issue.
+
 ## What to build
 
 This slice is operational, not code. Pick a small, well-scoped parent

--- a/docs/2026-05-05-research-minion/issues/07-slice-plan-comment-manual-build.md
+++ b/docs/2026-05-05-research-minion/issues/07-slice-plan-comment-manual-build.md
@@ -1,0 +1,72 @@
+# 07 — Slice plan as a comment + manual one-PR build (replaces #4)
+
+**Source PRD**: [../prd.md](../prd.md) (see the Design-revised banner)
+**Replaces**: [04 — slicer agent + child issues + status comment](./04-slicer-child-issues.md)
+**Blocked by**: [03 — prd-writer agent + PRD comment + parent label](./03-prd-writer-comment-label.md)
+
+> **Status: shipped.** Records the design that replaced #4's child-issue
+> + auto-cascade approach, after that approach proliferated issues and
+> collided feature PRs on a shared branch.
+
+## What to build
+
+The research run stops at *review artifacts*. After the PRD comment
+(slice #3), the `publisher` posts the slice plan as a **second comment**
+on the parent issue and labels the parent `minion-research-completed`.
+It opens **no** child issues, applies **no** `minion-approved`, and
+triggers **no** implementation.
+
+Implementation is a separate, manual, single-PR step. When jcleira has
+reviewed the PRD + slice plan, he labels the **parent** `minion-approved`
+(or comments `/minion build`); `minion.yml` fires `implement.md` once on
+the parent and produces **one** feature PR.
+
+For this to yield one clean PR per build, the minions runtime must give
+each build its own branch. The runtime previously derived the branch
+from `prog.ID + "-" + agent.Name` only — a constant
+`minion/implement-implement` shared across every build — so sequential
+builds collided into whatever PR was open on that branch. The runtime
+now appends the issue number: `minion/<prog>-<agent>-<issue>`.
+
+## Acceptance criteria
+
+- [x] `research.md`'s `publisher` posts the slice plan as a single
+  second comment on the parent, first line
+  `<!-- minion:research-slices parent=#<N> -->`, slices rendered as
+  readable Markdown.
+- [x] `publisher` opens no child issues and applies no `minion-approved`
+  / `minion-ready` label; the research run's only side effects are the
+  PRD comment, the slice-plan comment, and the `minion-research-completed`
+  label.
+- [x] Parent issue is left open; the research run never adds `minion-done`.
+- [x] Labeling the parent `minion-approved` (or `/minion build`) fires
+  `implement.md` once on the parent and produces exactly one feature PR.
+- [x] Each build uses a unique branch `minion/<prog>-<agent>-<issue>`
+  (minions ≥ v0.0.6); two builds never share a branch/PR.
+- [x] Verified end-to-end: partio-io/cli#437 → PRD + slice-plan comments,
+  no child issues, then one PR (#443) on branch
+  `minion/implement-implement-437`.
+
+## Modules touched
+
+- `partio-io/cli/.minions/programs/research.md` (`publisher` rewrite) —
+  partio-io/cli#436.
+- `partio-minions` runtime `internal/executor` + `cmd/minions/run.go`
+  (unique per-issue taskID) — partio-io/minions#130, released v0.0.6.
+- `partio-io/cli` workflow pins bumped to `minions@v0.0.6` —
+  partio-io/cli#439.
+
+## Test prior art
+
+- `partio-cli/.minions/programs/propose.md` — `gh issue comment`
+  patterns from inside an agent prompt.
+- `internal/executor/executor_test.go` — `TestBuildTaskID` table test +
+  the regression guard that two issues never share a taskID.
+
+## Out of scope
+
+- Idempotency / skip-if-marker-exists on the two comments — slice
+  [#5](./05-idempotency-rerun-skip.md) (premise revised for the comment
+  model).
+- First production smoke against a real `minion-proposal` issue — slice
+  [#6](./06-production-smoke-run.md).

--- a/docs/2026-05-05-research-minion/prd.md
+++ b/docs/2026-05-05-research-minion/prd.md
@@ -1,5 +1,27 @@
 # research-minion
 
+> **Design revised (2026-06) — shipped.** This PRD was written for a
+> *child-issue* design: the publisher opened one GitHub issue per slice,
+> each pre-labeled `minion-approved`, so `minion.yml` cascaded
+> `implement.md` per child. That was built (slice #4) and then
+> **replaced** — it proliferated issues and split one feature across many
+> PRs. The shipped design instead:
+> - **Research output is comments only.** The publisher posts the PRD as
+>   one comment and the slice plan as a second comment on the parent;
+>   it opens **no** child issues and applies **no** `minion-approved`.
+> - **Implementation is a manual, single-PR step.** jcleira labels the
+>   parent `minion-approved` (or `/minion build`) when ready; `implement.md`
+>   runs once on the parent and produces **one** feature PR.
+> - Each build gets its **own** branch `minion/<prog>-<agent>-<issue>`
+>   (minions ≥ v0.0.6), so builds never collide on a shared branch/PR.
+>
+> Shipped via partio-io/cli#436, partio-io/minions#130 + release v0.0.6,
+> and partio-io/cli#439. The current design is slice
+> [#07](./issues/07-slice-plan-comment-manual-build.md). Sections below
+> that describe child issues or the auto-cascade (Solution, several User
+> Stories, Idempotency contract, Build/Auto-cascade trigger semantics,
+> Specific interactions) predate this revision and are kept for history.
+
 ## Problem Statement
 
 The current minion system handles small, well-specified tasks well: a human files an issue on `partio-io/cli`, labels it `minion-approved` (or comments `/minion build`), and `implement.md` runs unattended to produce a PR. That fast path is sufficient when the spec is tight and the change is small.
@@ -19,10 +41,10 @@ A new GitHub label `minion-research` (or comment `/minion research`) on a parent
 1. **researcher** — drives an interview in the style of `/code-research`, walking the decision tree and writing Q&A to a transcript file in the worktree.
 2. **persona** — answers each question as jcleira would, grounded in argos's full `telos/*.md` (~5K chars) and `memory/*.md` (~120K chars across 48 files). Cloned fresh from `git@github.com:jcleira/argos.git` (master branch) into the workspace at workflow start. Strict directive in the prompt: use the substrate to *decide*, never quote or paraphrase personal content in any output.
 3. **prd-writer** — synthesizes the transcript into a PRD body.
-4. **slicer** — breaks the PRD into vertical-slice descriptions, one per child issue.
-5. **publisher** — uses the `gh` CLI to: post the PRD as a comment on the parent issue, open one child issue per slice, label parent with `minion-research-completed`, and post a status comment with child issue links.
+4. **slicer** — breaks the PRD into vertical-slice descriptions, one block per slice.
+5. **publisher** — uses the `gh` CLI to: post the PRD as a comment on the parent issue, post the slice plan as a second comment, and label the parent `minion-research-completed`. (Originally: opened one child issue per slice plus a status comment — replaced; see the Design-revised banner above.)
 
-Child issues are created with two labels: `minion-approved` (so the existing `minion.yml` workflow auto-fires `implement.md` for each) and `minion-research-output` (provenance, for filtering). The auto-fire cascade is intentional: jcleira approves the original parent issue once, and the system runs research → decomposition → implementation without further intervention. The only manual gate is final PR review — same as today's simple-task flow.
+The research run produces review artifacts only — no child issues, no `minion-approved`, no implementation. When jcleira is ready he labels the parent `minion-approved` (or comments `/minion build`); `minion.yml` then fires `implement.md` once on the parent and produces a single feature PR. The manual gate is deliberate: jcleira reviews the PRD + slice plan before any code is written.
 
 All artifacts stay on GitHub Issues and Pull Requests; no `docs/.../prd.md` or `docs/.../issues/*.md` files get committed. Idempotency markers (`<!-- minion:research run-id=<sha> -->` on the PRD comment, `<!-- minion:slice parent=#N -->` on child issue bodies) let re-runs detect existing artifacts and avoid duplication.
 
@@ -97,11 +119,12 @@ Three markers, each a single HTML comment line:
 
 The publisher agent's prompt instructs it to query the parent issue's existing comments via `gh issue view --json comments` and skip writing comments whose marker matches an existing one (regenerating instead).
 
-### Auto-cascade trigger semantics
+### Build trigger semantics (revised — see banner)
 
-- `minion-research` label OR `/minion research` comment on parent issue → fires `research.yml`.
-- `research.md`'s slicer agent creates child issues with `minion-approved` + `minion-research-output` labels. The `minion-approved` label is the existing trigger for `minion.yml`, so each child issue auto-fires `implement.md`.
-- No new wiring is needed between research and implement — they compose via the existing label.
+- `minion-research` label OR `/minion research` comment on parent issue → fires `research.yml`, which posts the PRD + slice-plan comments and stops.
+- Implementation is **not** auto-cascaded. When jcleira is ready he labels the **parent** `minion-approved` (or comments `/minion build`); `minion.yml` fires `implement.md` once on the parent → one feature PR.
+- Each build gets a unique branch `minion/<prog>-<agent>-<issue>` (minions ≥ v0.0.6), so re-runs and separate features never share a branch/PR.
+- (Originally: the slicer created child issues each pre-labeled `minion-approved`, auto-firing `implement.md` per child. Replaced — it proliferated issues and collided PRs on a shared branch.)
 
 ### Architectural decisions
 


### PR DESCRIPTION
## Objective

Reconcile the research-minion plan (PRD + slices) with the design that actually shipped.

## Why

The plan was written for a child-issue + auto-cascade design (slice #4). That shipped, then was deliberately replaced — it proliferated GitHub issues and collided feature PRs on a shared branch. The docs still described the discarded design, which misleads the next reader.

Shipped design: research posts the PRD + slice plan as **comments** on the parent; implementation is a **manual single-PR build** on a unique per-issue branch.

## How

- **prd.md**: design-revised banner up top (current design + the PRs that shipped it: partio-io/cli#436, partio-io/minions#130 / release v0.0.6, partio-io/cli#439); fixed the Solution and Build-trigger sections.
- **New slice #07**: records the shipped design, all criteria checked, with end-to-end verification (#437 → PR #443).
- **Slices #4/#5/#6**: banners — #4 superseded by #07; #5 premise revised (two comments, not child issues); #6 procedure revised (no cascade to pause).
- **issues.md**: marked #1–#4 done, added #7 (done), flagged #5/#6 as revised.

Docs only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
