### PR TITLE
docs: mark slice #08 criteria done (persona in-repo substrate)

### DIFF
--- a/docs/2026-05-05-research-minion/issues/08-persona-local-substrate.md
+++ b/docs/2026-05-05-research-minion/issues/08-persona-local-substrate.md
@@ -71,17 +71,17 @@ the in-repo substrate exists.
 
 ## Acceptance criteria
 
-- [ ] `research.yml` does not clone argos and references no `ARGOS_PAT`
+- [x] `research.yml` does not clone argos and references no `ARGOS_PAT`
   (verify; shipped in #454).
-- [ ] An in-repo `telos` + `memory` substrate exists in `partio-io/cli`
+- [x] An in-repo `telos` + `memory` substrate exists in `partio-io/cli`
   and contains no personal data (privacy review of the committed files).
-- [ ] `research.md`'s `persona` reads only the in-repo substrate; no
+- [x] `research.md`'s `persona` reads only the in-repo substrate; no
   `argos` path or clone reference remains anywhere in `research.md`.
 - [ ] A research run on a test issue with **no network access to argos**
   still produces a substantive PRD grounded in the in-repo substrate.
 - [ ] Privacy review of that run's public comments: no personal data,
   no verbatim substrate dumps.
-- [ ] The persona privacy directive is still present in the prompt.
+- [x] The persona privacy directive is still present in the prompt.
 
 ## Modules touched
 


### PR DESCRIPTION
## What

Marks acceptance criteria 1, 2, 3, and 6 of slice #08 as done in the issue file.

## Why

The persona in-repo-substrate implementation (sanitized `.minions/persona/` + `research.md` rewrite) is complete and verified in **partio-io/cli** (separate PR there). Criteria 4 & 5 stay open — they require a live research run (spends API budget, posts public comments), which is the #6 production smoke.

## Note

The `issues.md` index row is intentionally **not** flipped to `[x]` since 4/5 remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
